### PR TITLE
fix: avoid panic in test when SOLVER_PRIVATE_KEY undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ Tips:
 
 If your module is not deterministic, compute providers will not adopt it and add it to their allowlists.
 
+
+### Writing Advanced Modules
+
+1. `subt`: Substitutions are not possible due to [#14](https://github.com/bacalhau-project/lilypad/issues/14). `subt`- enables substitution. It implementes [printf](https://pkg.go.dev/text/template#Template.Funcs) under the hood. Hence the usage is same.
+
+    
+
+

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If your module is not deterministic, compute providers will not adopt it and add
 
 1. `subt`: Substitutions are not possible due to [#14](https://github.com/bacalhau-project/lilypad/issues/14). `subt`- enables substitution. It implementes [printf](https://pkg.go.dev/text/template#Template.Funcs) under the hood. Hence the usage is same.
 
+
     
 
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ chmod +x lilypad
 sudo mv lilypad /usr/local/bin/lilypad
 ```
 
+You can also, at your option, choose to compile Lilypad using Go and install it that way on any machine that supports the Go toolchain.
+
 ## Run a job
 
 ```

--- a/README.md
+++ b/README.md
@@ -130,9 +130,24 @@ If your module is not deterministic, compute providers will not adopt it and add
 
 ### Writing Advanced Modules
 
-1. `subt`: Substitutions are not possible due to [#14](https://github.com/bacalhau-project/lilypad/issues/14). `subt`- enables substitution. It implementes [printf](https://pkg.go.dev/text/template#Template.Funcs) under the hood. Hence the usage is same.
+1. `subt`:
+The `subt` function allows for substitutions in your template, a feature that addresses the issue outlined in [#14](https://github.com/bacalhau-project/lilypad/issues/14).
 
+This function is a workaround for the lack of direct substitution support in the module. It implements the [printf](https://pkg.go.dev/text/template#Template.Funcs) function under the hood, which allows you to format strings with placeholders.
 
+<details>
+  <summary> 
+    Usage    
+  </summary>
+    The `subt` function can be used in the same way as the `printf` function in Go. You pass in a format string, followed by values that correspond to the placeholders in the format string.
+    ```
+    const templateText = `
+    {{ subt "Hello %s" .name }}
+    `
+
+    ```
+</details>
+  
     
 
 

--- a/README.md
+++ b/README.md
@@ -137,16 +137,17 @@ This function is a workaround for the lack of direct substitution support in the
 
 <details>
   <summary> 
-    Usage    
+    Usage   
   </summary>
     The `subt` function can be used in the same way as the `printf` function in Go. You pass in a format string, followed by values that correspond to the placeholders in the format string.
     ```
     const templateText = `
     {{ subt "Hello %s" .name }}
     `
-
     ```
 </details>
+
+[Example Code](https://go.dev/play/p/oBgc2Cetug3)
   
     
 

--- a/README.md
+++ b/README.md
@@ -32,25 +32,20 @@ The faucet will give you both ETH (to pay for gas) and LP (to stake and pay for 
 
 ## Install CLI
 
-#### 1. With Go toolchain 
+Download the latest release of Lilypad for your platform. Both the amd64/x86_64 and arm64 variants of macOS and Linux are supported. (If you are on Apple Silicon, you'll want arm64).
 
-```shell
-go install github.com/bacalhau-project/lilypad@latest
-```
-You may then need to set:
-```
-export SERVICE_SOLVER="0xd4646ef9f7336b06841db3019b617ceadf435316"
-export SERVICE_MEDIATORS="0x2d83ced7562e406151bd49c749654429907543b4"
-```
-
-#### 2. Via officially released binaries
-
-Caveat: only supports x86_64 Linux
+The commands below will automatically detect your OS and processor architecture and download the correct Lilypad build for your machine.
 
 ```
-curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-a9f88f7/lilypad
+# Detect your machine's architecture and set it as $OSARCH
+OSARCH=$(uname -m | awk '{if ($0 ~ /arm64|aarch64/) print "arm64"; else if ($0 ~ /x86_64|amd64/) print "amd64"; else print "unsupported_arch"}') && export OSARCH
+# Detect your operating system and set it as $OSNAME
+OSNAME=$(uname -s | awk '{if ($1 == "Darwin") print "darwin"; else if ($1 == "Linux") print "linux"; else print "unsupported_os"}') && export OSNAME;
+# Download the latest production build
+curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-701b8cb/lilypad-$OSNAME-$OSARCH
+# Make Lilypad executable and install it
 chmod +x lilypad
-sudo mv lilypad /usr/local/bin
+sudo mv lilypad /usr/local/bin/lilypad
 ```
 
 ## Run a job

--- a/TESTNETDEPLOY.md
+++ b/TESTNETDEPLOY.md
@@ -109,6 +109,27 @@ Check the balances
 ./stack fund-services-tokens
 ```
 
+## Update the .env file with contract addresses
+
+Make sure NETWORK in `hardhat/.env` is set to `sepolia`.
+
+Append the deployed contract addresses to the `.env` file:
+
+```bash
+./stack print-contract-env >> .env
+```
+
+That should add seven contract addresses to the `.env` file. For example:
+```
+export WEB3_CONTROLLER_ADDRESS=0x433C91FA54b9c11550b07672E1FA2b06860e5b05
+export WEB3_TOKEN_ADDRESS=0x90bC5e91B2bC6BBa240001B169fd73DeA75E072A
+export WEB3_MEDIATION_ADDRESS=0xe294485d0C03adCe1BE2c2791522A6c0585A4f7B
+export WEB3_JOBCREATOR_ADDRESS=0x4aC3C9F7e431dce628440b5037d23890c28E5C3F
+export WEB3_PAYMENTS_ADDRESS=0xC5b1737A2282E6283c54f67bC401426058BC170F
+export WEB3_STORAGE_ADDRESS=0x79Ee2d28eDDd9Ee0b68613b29Dab474623F8D1c6
+export WEB3_USERS_ADDRESS=0x70eC3b0aFA059174dD54d7702624f1Dd402b706b
+```
+
 ### Run Services
 
 Run the following commands in separate terminals:

--- a/hardhat/scripts/print-contract-env.ts
+++ b/hardhat/scripts/print-contract-env.ts
@@ -17,7 +17,6 @@ async function main() {
   const storageAddress = await getStorageAddress()
   const usersAddress = await getUsersAddress()
   
-  console.log(`export WEB3_RPC_URL=ws://localhost:8546`)
   console.log(`export WEB3_CONTROLLER_ADDRESS=${controllerAddress}`)
   console.log(`export WEB3_TOKEN_ADDRESS=${tokenAddress}`)
   console.log(`export WEB3_MEDIATION_ADDRESS=${mediationAddress}`)

--- a/stack
+++ b/stack
@@ -243,6 +243,7 @@ function print-contract-env() {
 
 function print-local-dev-env() {
   print-contract-env
+  echo "export WEB3_RPC_URL=ws://localhost:8546"
 }
 
 function fund-services-ether() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bacalhau-project/lilypad/pkg/web3"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testOptions struct {
@@ -117,7 +118,6 @@ func getJobCreatorOptions(options testOptions) (jobcreator.JobCreatorOptions, er
 		// this should point to the shortcut
 		"cowsay:v0.0.2",
 	})
-
 	if err != nil {
 		return ret, err
 	}
@@ -131,7 +131,6 @@ func testStackWithOptions(
 	commandCtx *system.CommandContext,
 	options testOptions,
 ) (*jobcreator.RunJobResults, error) {
-
 	solver, err := getSolver(t, options)
 	if err != nil {
 		return nil, err
@@ -163,7 +162,6 @@ func testStackWithOptions(
 	}
 
 	result, err := jobcreator.RunJob(commandCtx, jobCreatorOptions, func(evOffer data.JobOfferContainer) {
-
 	})
 	if err != nil {
 		return nil, err
@@ -186,7 +184,7 @@ func TestNoModeration(t *testing.T) {
 		executor:         executorOptions,
 	})
 
-	assert.NoError(t, err, "there was an error running the job")
+	require.NoError(t, err, "there was an error running the job")
 	assert.Equal(t, "123", result.Result.DataID, "the data ID was correct")
 
 	localPath := solver.GetDownloadsFilePath(result.Result.DealID)


### PR DESCRIPTION
Avoid dereferencing nil result when an error is returned from testStackWithOptions