### PR TITLE
Update contract addresses for Aurora reset

### DIFF
--- a/docs/smart-contract-jobs.md
+++ b/docs/smart-contract-jobs.md
@@ -8,7 +8,7 @@ It works in tandem with the `lilypad jobcreator` on-chain which will watch the o
 
 You will need to know the contract address for the on-chain job creator so we can submit transactions to it.
 
-The production controller address is `0xCCAaFD2AdD790788436f10e2C84585C46388b9aF` and you can ask it for the address of the on-chain job creator `getJobCreatorAddress()`
+The production controller address is `0x8e136587e3e5266d5244f6aa896E5CAf8E969946` and you can ask it for the address of the on-chain job creator `getJobCreatorAddress()`
 
 Running a job involves 2 phases:
 

--- a/ops/systemd/job-creator.service
+++ b/ops/systemd/job-creator.service
@@ -8,8 +8,8 @@ Environment="LOG_TYPE=json"
 Environment="LOG_LEVEL=debug"
 Environment="HOME=/app/lilypad"
 EnvironmentFile=/app/lilypad/job-creator.env
-Environment="SERVICE_SOLVER=0xd4646ef9f7336b06841db3019b617ceadf435316"
-Environment="SERVICE_MEDIATORS=0x2d83ced7562e406151bd49c749654429907543b4"
+Environment="SERVICE_SOLVER=0x346d811cbb883548252418121f5bb0371eb07049"
+Environment="SERVICE_MEDIATORS=0xA99fd5f0D91664417401F63d72a41eCdDC2d6961"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/lilypad jobcreator

--- a/ops/systemd/mediator.service
+++ b/ops/systemd/mediator.service
@@ -8,7 +8,7 @@ Environment="LOG_TYPE=json"
 Environment="LOG_LEVEL=debug"
 Environment="HOME=/app/lilypad"
 EnvironmentFile=/app/lilypad/mediator.env
-Environment="SERVICE_SOLVER=0xd4646ef9f7336b06841db3019b617ceadf435316"
+Environment="SERVICE_SOLVER=0x346d811cbb883548252418121f5bb0371eb07049"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/lilypad mediator

--- a/ops/systemd/resource-provider-gpu.service
+++ b/ops/systemd/resource-provider-gpu.service
@@ -9,8 +9,8 @@ Environment="LOG_LEVEL=debug"
 Environment="HOME=/app/lilypad"
 Environment="OFFER_GPU=1"
 EnvironmentFile=/app/lilypad/resource-provider-gpu.env
-Environment="SERVICE_SOLVER=0xd4646ef9f7336b06841db3019b617ceadf435316"
-Environment="SERVICE_MEDIATORS=0x2d83ced7562e406151bd49c749654429907543b4"
+Environment="SERVICE_SOLVER=0x346d811cbb883548252418121f5bb0371eb07049"
+Environment="SERVICE_MEDIATORS=0xA99fd5f0D91664417401F63d72a41eCdDC2d6961"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/lilypad resource-provider 

--- a/ops/systemd/resource-provider.service
+++ b/ops/systemd/resource-provider.service
@@ -8,8 +8,8 @@ Environment="LOG_TYPE=json"
 Environment="LOG_LEVEL=debug"
 Environment="HOME=/app/lilypad"
 EnvironmentFile=/app/lilypad/resource-provider.env
-Environment="SERVICE_SOLVER=0xd4646ef9f7336b06841db3019b617ceadf435316"
-Environment="SERVICE_MEDIATORS=0x2d83ced7562e406151bd49c749654429907543b4"
+Environment="SERVICE_SOLVER=0x346d811cbb883548252418121f5bb0371eb07049"
+Environment="SERVICE_MEDIATORS=0xA99fd5f0D91664417401F63d72a41eCdDC2d6961"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/lilypad resource-provider

--- a/pkg/options/services.go
+++ b/pkg/options/services.go
@@ -9,8 +9,8 @@ import (
 
 func GetDefaultServicesOptions() data.ServiceConfig {
 	return data.ServiceConfig{
-		Solver:   GetDefaultServeOptionString("SERVICE_SOLVER", "0xd4646ef9f7336b06841db3019b617ceadf435316"),
-		Mediator: GetDefaultServeOptionStringArray("SERVICE_MEDIATORS", []string{"0x2d83ced7562e406151bd49c749654429907543b4"}),
+		Solver:   GetDefaultServeOptionString("SERVICE_SOLVER", "0x346d811cbb883548252418121f5bb0371eb07049"),
+		Mediator: GetDefaultServeOptionStringArray("SERVICE_MEDIATORS", []string{"0xA99fd5f0D91664417401F63d72a41eCdDC2d6961"}),
 	}
 }
 

--- a/pkg/options/web3.go
+++ b/pkg/options/web3.go
@@ -18,7 +18,7 @@ func GetDefaultWeb3Options() web3.Web3Options {
 		ChainID:    GetDefaultServeOptionInt("WEB3_CHAIN_ID", 1337), //nolint:gomnd
 
 		// contract addresses
-		ControllerAddress: GetDefaultServeOptionString("WEB3_CONTROLLER_ADDRESS", "0xCCAaFD2AdD790788436f10e2C84585C46388b9aF"),
+		ControllerAddress: GetDefaultServeOptionString("WEB3_CONTROLLER_ADDRESS", "0x8e136587e3e5266d5244f6aa896E5CAf8E969946"),
 		PaymentsAddress:   GetDefaultServeOptionString("WEB3_PAYMENTS_ADDRESS", ""),
 		StorageAddress:    GetDefaultServeOptionString("WEB3_STORAGE_ADDRESS", ""),
 		UsersAddress:      GetDefaultServeOptionString("WEB3_USERS_ADDRESS", ""),


### PR DESCRIPTION
This updates all addresses throughout Lilypad to use the new Aurora contracts, upon the reset of our testnet.

This completes our migration to the new Aurora infra.