### PR TITLE
feat: add task section to template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,10 @@
 ### Summary
 Provide a one line summary and link to any relevant references
 
+### Task/Issue reference
+
+Closes: add_link_here
+
 ### Details (optional)
 Add any additional details that might help Code Reviewers digest this PR
 


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
This change adds a section to reference the task/issue (this way, when looking at the issue in the board it links to the PR)

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/42