### PR TITLE
Get ENVS from Doppler for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hardhat/artifacts
 hardhat/cache
 hardhat/deployments/hardhat
 hardhat/deployments/localhost
+hardhat/deployments/local_l2
 hardhat/deployments/geth
 hardhat/typechain-types
 node_modules/*

--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -7,9 +7,25 @@ import 'hardhat-deploy'
 import * as dotenv from 'dotenv'
 
 import {
-  ACCOUNT_ADDRESSES,
-  PRIVATE_KEYS,
+  loadAddress,
+  loadPrivateKey,
+  getAllKeys,
+  setAccount,
+  getAllAddresses,
+  ACCOUNTS
 } from './utils/accounts'
+
+//override default publically known keys by doppler config
+for (const acc of ACCOUNTS) {
+  if (process.env[acc.name.toUpperCase()+'_PRIVATE_KEY'] && process.env[acc.name.toUpperCase()+'_ADDRESS']) {
+    acc.address = loadAddress(acc.name, process.env[acc.name+'_ADDRESS']?.toString() ?? '')
+    acc.privateKey = loadPrivateKey(acc.name, process.env[acc.name+'_PRIVATE_KEY']?.toString() ?? '')
+    setAccount(acc)
+  }
+}
+
+const PRIVATE_KEYS = getAllKeys()
+const ACCOUNT_ADDRESSES = getAllAddresses()
 
 const ENV_FILE = process.env.DOTENV_CONFIG_PATH || '../.env'
 dotenv.config({ path: ENV_FILE })
@@ -31,6 +47,36 @@ const config: HardhatUserConfig = {
     },
     sepolia: {
       url: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
+      accounts: PRIVATE_KEYS,
+    },
+    local_l2: {
+      url: 'http://localhost:8547',
+      chainId: 412346,
+      accounts: PRIVATE_KEYS,
+    },
+    arbitrumSepolia: {
+      url: 'https://sepolia-rollup.arbitrum.io/rpc',
+      chainId: 421614,
+      accounts: PRIVATE_KEYS
+    },
+    arbitrumOne: {
+      chainId: 42161,
+      url: 'https://arb1.arbitrum.io/rpc',
+      accounts: PRIVATE_KEYS
+    },
+    arbitrumNova: {
+      chainId: 42170,
+      url: 'https://nova.arbitrum.io/rpc',
+      accounts: PRIVATE_KEYS
+    },
+    mumbai: {
+      chainId: 80001,
+      url: `https://polygon-testnet.public.blastapi.io`,
+      accounts: PRIVATE_KEYS,
+    },
+    polygon: {
+      chainId: 137,
+      url: `https://rpc.ankr.com/polygon`,
       accounts: PRIVATE_KEYS,
     },
   },

--- a/hardhat/utils/accounts.ts
+++ b/hardhat/utils/accounts.ts
@@ -84,3 +84,22 @@ export const getAccount = (name: string) => {
   }
   return account
 }
+export const getAllAddresses = () => {
+  return ACCOUNTS.reduce<Record<string, string>>((all, acc) => {
+    all[acc.name] = acc.address
+    return all
+  }, {})
+}
+export const getAllKeys = () => ACCOUNTS.map(acc => acc.privateKey)
+export const setAccount = (acc: Account) => {
+  let foundAccount = ACCOUNTS.find((a) => a.name === acc.name);
+  if (foundAccount) {
+    console.log("account already exists, updating");
+    foundAccount.address = acc.address;
+    foundAccount.privateKey = acc.privateKey;
+    foundAccount.metadata = acc.metadata;
+    foundAccount.name = acc.name;
+  }
+  NAMED_ACCOUNTS[acc.name] = acc;
+  ACCOUNT_ADDRESSES[acc.name] = acc.address;
+};

--- a/stack
+++ b/stack
@@ -343,5 +343,10 @@ function integration-tests() {
   cd test
   doppler run -p integration-tests -c dev -- go test -v -count 1 .
 }
+function chain-deploy() {
+  cd hardhat
+  echo $@
+  doppler run -p chain -c $@ -- yarn hardhat deploy
+}
 
 eval "$@"


### PR DESCRIPTION
Support to local_l2, arbitrum, polygon

**Logic** - thorough check (from everybody doing review)

### Summary
Easily deploy to any chain using doppler configuration.
Example:
./stack chain-deploy dev_personal

See dev_personal configuration under chain project in doppler

This enhancement should not effect any existing workflows.