### PR TITLE
feat: add tracking job and module events

### DIFF
--- a/pkg/jobcreator/onchain_jobcreator.go
+++ b/pkg/jobcreator/onchain_jobcreator.go
@@ -6,11 +6,12 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lilypad-tech/lilypad/pkg/data"
+	"github.com/lilypad-tech/lilypad/pkg/metricsDashboard"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	jobcreatorweb3 "github.com/lilypad-tech/lilypad/pkg/web3/bindings/jobcreator"
-	"github.com/davecgh/go-spew/spew"
 )
 
 const JOB_PRICE = 2
@@ -62,6 +63,8 @@ func (jobCreator *OnChainJobCreator) Start(ctx context.Context, cm *system.Clean
 		errorChan <- err
 		return errorChan
 	}
+
+	jobCreator.SubscribeToJobOfferUpdates(metricsDashboard.TrackJobOfferUpdate)
 
 	jobCreator.controller.SubscribeToJobOfferUpdates(func(evOffer data.JobOfferContainer) {
 		if evOffer.State != data.GetAgreementStateIndex("ResultsAccepted") {

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -1,0 +1,54 @@
+package metricsDashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/lilypad-tech/lilypad/pkg/data"
+)
+
+var host = os.Getenv("API_HOST")
+var endpoint = "metrics-dashboard/logs"
+var url = host + endpoint
+
+func TrackEvent(json string) {
+	data := []byte(json)
+
+	client := &http.Client{Timeout: time.Second * 1}
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	resp.Body.Close()
+}
+
+func TrackJobOfferUpdate(evOffer data.JobOfferContainer) {
+	var module = evOffer.JobOffer.Module.Name
+	if module == "" {
+		module = evOffer.JobOffer.Module.Repo + ":" + evOffer.JobOffer.Module.Hash
+	}
+
+	data := map[string]interface{}{
+		"ID":         evOffer.ID,
+		"JobOfferID": evOffer.JobOffer.ID,
+		"CreatedAt":  evOffer.JobOffer.CreatedAt,
+		"JobCreator": evOffer.JobCreator,
+		"DealID":     evOffer.DealID,
+		"State":      evOffer.State,
+		"Module":     module,
+		"Timestamp":  time.Now().UnixMilli(),
+		"Event":      "JobOfferUpdate",
+	}
+	byts, _ := json.Marshal(data)
+	payload := string(byts)
+
+	TrackEvent(payload)
+}

--- a/stack
+++ b/stack
@@ -218,7 +218,7 @@ function run-cowsay-onchain() {
 
 function solver() {
   echo "- Reminder to do doppler setup to project->solver and config->dev"
-  doppler run -p solver -c dev -- go run . solver
+  doppler run --preserve-env -p solver -c dev -- go run . solver
 }
 
 function solver-docker-build() {
@@ -245,7 +245,7 @@ function solver-docker-run() {
 
 function job-creator() {
   echo "- Reminder to do doppler setup to project->job-creator and config->dev"
-  doppler run -p job-creator -c dev -- go run . jobcreator
+  doppler run --preserve-env -p job-creator -c dev -- go run . jobcreator
 }
 
 function job-creator-docker-build() {
@@ -270,7 +270,7 @@ function job-creator-docker-run() {
 
 function resource-provider() {
   echo "- Reminder to do doppler setup to project->resource-provider and config->dev"
-  doppler run -p resource-provider -c dev -- go run . resource-provider "$@"
+  doppler run --preserve-env -p resource-provider -c dev -- go run . resource-provider "$@"
 }
 
 function resource-provider-docker-build() {
@@ -342,6 +342,13 @@ function unit-tests() {
 function integration-tests() {
   cd test
   doppler run -p integration-tests -c dev -- go test -v -count 1 .
+}
+
+############################################################################
+# run
+############################################################################
+function run() {
+  doppler run --preserve-env -p run -c dev -- go run . run "$@"
 }
 
 eval "$@"


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes allow to track job offer updates which will give us information about the `jobs`, `modules` and `users` run in the network for the metrics dashboard. I've tested both `cli` and `onchain` jobs and these changes capture events on both types of runs at the server level, not at the client level which means we will track events without users having to update their cli tools.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/44

### How to test this code? (optional)

If you want to fully test this you should clone the [API repo](https://github.com/Lilypad-Tech/api), and then run it (follow readme instructions, a db is needed even though we still are not inserting data to it). Once the api server is running, setup a full local lilypad network and execute either a cli or onchain run and see how the events get captured in the api's logs.

* Update: if you plan on running the api server, create a `api-repo-folder/data/logs` folder, as the code expects it and does not currently create it.