### PR TITLE
Add systemd watchdog support to service.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJF7HpyG8M=
 github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/ops/systemd/bacalhau.service
+++ b/ops/systemd/bacalhau.service
@@ -11,6 +11,7 @@ Environment="BACALHAU_SERVE_IPFS_PATH=/app/data/ipfs"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/bacalhau serve --node-type compute,requester --peer none --private-internal-ipfs=false --job-selection-accept-networked
+WatchdogSec=20s
 
 [Install]
 WantedBy=multi-user.target

--- a/ops/systemd/resource-provider.service
+++ b/ops/systemd/resource-provider.service
@@ -13,6 +13,7 @@ Environment="SERVICE_MEDIATORS=0xc66b9b74e307f30e7af79c03fee6ceb8b1ced997"
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/lilypad resource-provider
+WatchdogSec=20s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [ x ] **Logic** - thorough check (from everybody doing review)

### Summary
Uses the systemclt watchdog to automatically restart the Resource Provider service if it becomes unresponsive.

### Task/Issue reference

[Closes: add_link_here](https://github.com/Lilypad-Tech/infra/issues/2)

### Details (optional)
additional services can be included by specifying:
WatchdogSec=20s

in their .service file

### How to test this code? (optional)

systemctl daemon-reload
systemctl restart resource-provider

Monitor the notifications:
journalctl -u resource-provider -f

there should be a "Watchdog notification" message



