### PR TITLE
feat: Add network command line option and embedded configs

### DIFF
--- a/.github/workflows/devnet_deploy.yml
+++ b/.github/workflows/devnet_deploy.yml
@@ -61,6 +61,7 @@ jobs:
             --build-arg="expose_via=cloudflare" \
             --build-arg="cloudflare_token=${CLOUDFLARE_TOKEN_SOLVER}"\
             --build-arg="doppler_config=devnet" \
+            --build-arg="network=devnet" \
             .
           docker tag $ECR_REPOSITORY_SOLVER:latest $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
@@ -122,6 +123,7 @@ jobs:
             -t $ECR_REPOSITORY_JOB_CREATOR \
             -f ./docker/job-creator/Dockerfile \
             --build-arg doppler_config=devnet \
+            --build-arg="network=devnet" \
             .
           docker tag $ECR_REPOSITORY_JOB_CREATOR:latest $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest

--- a/.github/workflows/testnet_deploy_services.yml
+++ b/.github/workflows/testnet_deploy_services.yml
@@ -34,6 +34,7 @@ jobs:
             -t $ECR_REPOSITORY_SOLVER \
             -f ./docker/solver/Dockerfile \
             --build-arg="expose_via=cloudflare" \
+            --build-arg="network=testnet" \
             .
           docker tag $ECR_REPOSITORY_SOLVER:latest $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
@@ -94,6 +95,7 @@ jobs:
           docker build \
             -t $ECR_REPOSITORY_JOB_CREATOR \
             -f ./docker/job-creator/Dockerfile \
+            --build-arg="network=testnet" \
             .
           docker tag $ECR_REPOSITORY_JOB_CREATOR:latest $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ hardhat/deployments/localhost
 hardhat/deployments/geth
 hardhat/typechain-types
 node_modules/*
+# Ignore the binary executable
 lilypad
+!cmd/lilypad
 .env
 *.env
 .env.*

--- a/cmd/lilypad/jobcreator.go
+++ b/cmd/lilypad/jobcreator.go
@@ -17,6 +17,8 @@ func newJobCreatorCmd() *cobra.Command {
 		Long:    "Start the lilypad job creator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			optionsfactory.CheckDeprecation(options.Offer.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessOnChainJobCreatorOptions(options, args, network)
 			if err != nil {

--- a/cmd/lilypad/jobcreator.go
+++ b/cmd/lilypad/jobcreator.go
@@ -17,7 +17,8 @@ func newJobCreatorCmd() *cobra.Command {
 		Long:    "Start the lilypad job creator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options, err := optionsfactory.ProcessOnChainJobCreatorOptions(options, args)
+			network, _ := cmd.Flags().GetString("network")
+			options, err := optionsfactory.ProcessOnChainJobCreatorOptions(options, args, network)
 			if err != nil {
 				return err
 			}

--- a/cmd/lilypad/mediator.go
+++ b/cmd/lilypad/mediator.go
@@ -19,7 +19,8 @@ func newMediatorCmd() *cobra.Command {
 		Long:    "Start the lilypad mediator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			options, err := optionsfactory.ProcessMediatorOptions(options)
+			network, _ := cmd.Flags().GetString("network")
+			options, err := optionsfactory.ProcessMediatorOptions(options, network)
 			if err != nil {
 				return err
 			}

--- a/cmd/lilypad/mediator.go
+++ b/cmd/lilypad/mediator.go
@@ -19,6 +19,8 @@ func newMediatorCmd() *cobra.Command {
 		Long:    "Start the lilypad mediator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(options.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessMediatorOptions(options, network)
 			if err != nil {

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -18,7 +18,8 @@ func newResourceProviderCmd() *cobra.Command {
 		Long:    "Start the lilypad resource-provider service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			options, err := optionsfactory.ProcessResourceProviderOptions(options)
+			network, _ := cmd.Flags().GetString("network")
+			options, err := optionsfactory.ProcessResourceProviderOptions(options, network)
 			if err != nil {
 				return err
 			}

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -18,6 +18,8 @@ func newResourceProviderCmd() *cobra.Command {
 		Long:    "Start the lilypad resource-provider service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(options.Offers.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessResourceProviderOptions(options, network)
 			if err != nil {

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -21,6 +21,10 @@ func NewRootCmd() *cobra.Command {
 		Short: "Lilypad",
 		Long:  fmt.Sprintf("Lilypad: %s \nCommit: %s \n", VERSION, COMMIT_SHA),
 	}
+
+	var network string
+	RootCmd.PersistentFlags().StringVarP(&network, "network", "n", "testnet", "Sets a target network configuration")
+
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())
 	RootCmd.AddCommand(newRunCmd())

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -8,12 +8,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/jobcreator"
 	optionsfactory "github.com/lilypad-tech/lilypad/pkg/options"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	"github.com/lilypad-tech/lilypad/pkg/system"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/theckman/yacspin"

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -27,6 +27,8 @@ func newRunCmd() *cobra.Command {
 		Long:    "Run a job on the Lilypad network.",
 		Example: "run cowsay:v0.0.1 -i Message=moo",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			optionsfactory.CheckDeprecation(options.Offer.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessJobCreatorOptions(options, args, network)
 			if err != nil {

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -27,7 +27,8 @@ func newRunCmd() *cobra.Command {
 		Long:    "Run a job on the Lilypad network.",
 		Example: "run cowsay:v0.0.1 -i Message=moo",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options, err := optionsfactory.ProcessJobCreatorOptions(options, args)
+			network, _ := cmd.Flags().GetString("network")
+			options, err := optionsfactory.ProcessJobCreatorOptions(options, args, network)
 			if err != nil {
 				return err
 			}

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -18,7 +18,8 @@ func newSolverCmd() *cobra.Command {
 		Long:    "Start the lilypad solver service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			options, err := optionsfactory.ProcessSolverOptions(options)
+			network, _ := cmd.Flags().GetString("network")
+			options, err := optionsfactory.ProcessSolverOptions(options, network)
 			if err != nil {
 				return err
 			}

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -1,6 +1,7 @@
 package lilypad
 
 import (
+	"github.com/lilypad-tech/lilypad/pkg/data"
 	optionsfactory "github.com/lilypad-tech/lilypad/pkg/options"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	memorystore "github.com/lilypad-tech/lilypad/pkg/solver/store/memory"
@@ -18,6 +19,8 @@ func newSolverCmd() *cobra.Command {
 		Long:    "Start the lilypad solver service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(data.ServiceConfig{}, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessSolverOptions(options, network)
 			if err != nil {

--- a/docker/job-creator/Dockerfile
+++ b/docker/job-creator/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:latest as base
 WORKDIR /usr/src/app
 
+ARG network=dev
+
 COPY . .
 RUN go mod download && go mod verify
 RUN go build -v .
@@ -10,7 +12,7 @@ RUN (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/insta
 
 RUN touch run
 RUN echo "#!/bin/bash" >> run
-RUN echo "doppler run -- lilypad jobcreator" >> run
+RUN echo "doppler run -- lilypad jobcreator --network $network" >> run
 RUN chmod +x run
 
 CMD ["/bin/bash", "./run"]

--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:latest as base
 WORKDIR /usr/src/app
 
 ARG doppler_config=dev
+ARG network=dev
 ARG DOPPLER_TOKEN_BACALHAU
 ARG DOPPLER_TOKEN_RESOURCE_PROVIDER
 
@@ -21,7 +22,7 @@ RUN (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/insta
 RUN touch run
 RUN echo "#!/bin/bash" >> run
 #RUN echo "doppler run --token=$DOPPLER_TOKEN_BACALHAU -p bacalhau -c $doppler_config -- ./stack bacalhau-serve &" >> run
-RUN echo "doppler run --token=$DOPPLER_TOKEN_RESOURCE_PROVIDER -p resource-provider -c $doppler_config -- lilypad resource-provider" >> run
+RUN echo "doppler run --token=$DOPPLER_TOKEN_RESOURCE_PROVIDER -p resource-provider -c $doppler_config -- lilypad resource-provider --network $network" >> run
 RUN chmod +x run
 
 CMD ["/bin/bash", "./run"]

--- a/docker/solver/Dockerfile
+++ b/docker/solver/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:latest as base
 WORKDIR /usr/src/app
 
 ARG arch=amd64
+ARG network=dev
 
 COPY . .
 RUN go mod download && go mod verify
@@ -18,11 +19,11 @@ RUN echo "#!/bin/bash" >> run
 FROM base AS expose-cloudflare
 RUN curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${arch}.deb
 RUN dpkg -i cloudflared.deb
-RUN echo "doppler run --command \"cloudflared tunnel run & lilypad solver\"" >> run
+RUN echo "doppler run --command \"cloudflared tunnel run & lilypad solver --network $network\"" >> run
 
 FROM base AS expose-local
 EXPOSE 8080
-RUN echo "doppler run -- lilypad solver" >> run
+RUN echo "doppler run -- lilypad solver --network $network" >> run
 
 FROM expose-$expose_via AS FINAL
 RUN chmod +x run

--- a/docs/smart-contract-jobs.md
+++ b/docs/smart-contract-jobs.md
@@ -8,7 +8,7 @@ It works in tandem with the `lilypad jobcreator` on-chain which will watch the o
 
 You will need to know the contract address for the on-chain job creator so we can submit transactions to it.
 
-The production controller address is `0x8e136587e3e5266d5244f6aa896E5CAf8E969946` and you can ask it for the address of the on-chain job creator `getJobCreatorAddress()`
+The production controller address is `0xF2fD1B9b262982F12446149A27d8901Ac68dcB59` and you can ask it for the address of the on-chain job creator `getJobCreatorAddress()`
 
 Running a job involves 2 phases:
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lilypad-tech/lilypad
 go 1.20
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ethereum/go-ethereum v1.13.4
 	github.com/fatih/color v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/pkg/data/types.go
+++ b/pkg/data/types.go
@@ -83,8 +83,8 @@ const (
 // by the RP and JC - the solver will find an intersection
 // of these and attach them to the deal
 type ServiceConfig struct {
-	Solver   string   `json:"solver"`
-	Mediator []string `json:"mediator"`
+	Solver   string   `json:"solver" toml:"solver"`
+	Mediator []string `json:"mediator" toml:"mediator"`
 }
 
 // posted to the solver by a job creator

--- a/pkg/options/config.go
+++ b/pkg/options/config.go
@@ -1,0 +1,37 @@
+package options
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"github.com/lilypad-tech/lilypad/pkg/data"
+	"github.com/lilypad-tech/lilypad/pkg/web3"
+)
+
+//go:embed configs
+var fs embed.FS
+
+type Config struct {
+	Web3          web3.Web3Options   `toml:"web3"`
+	ServiceConfig data.ServiceConfig `toml:"services"`
+}
+
+// TODO(bgins) Check for user-defined config files
+func getConfig(network string) (*Config, error) {
+	var config Config
+
+	path := fmt.Sprintf("configs/%s.toml", network)
+	config_toml, err := fs.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("network %s does not exist", network)
+	}
+
+	_, err = toml.Decode(string(config_toml), &config)
+	if err != nil {
+		return nil, errors.New("unable to parse config file")
+	}
+
+	return &config, nil
+}

--- a/pkg/options/configs/dev.toml
+++ b/pkg/options/configs/dev.toml
@@ -1,0 +1,14 @@
+[services]
+solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
+
+[web3]
+rpc_url = "ws://localhost:8546"
+chain_id = 421614
+controller_address = "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1"
+payments_address = "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
+storage_address = "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+users_address = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+token_address = "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
+mediation_address = "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
+jobcreator_address = "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"

--- a/pkg/options/configs/devnet.toml
+++ b/pkg/options/configs/devnet.toml
@@ -1,0 +1,14 @@
+[services]
+solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
+
+[web3]
+rpc_url = "wss://devnet-chain-ws.lilypad.tech"
+chain_id = 421614
+controller_address = "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1"
+payments_address = "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
+storage_address = "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+users_address = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+token_address = "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
+mediation_address = "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
+jobcreator_address = "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -1,0 +1,14 @@
+[services]
+solver = "0xe05e1b71955da4934938a6b16f97e1db9de6b764"
+mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
+
+[web3]
+rpc_url = "wss://arbitrum-sepolia.infura.io/ws/v3/07472a48382e4679ae818aad0c21cf90"
+chain_id = 421614
+controller_address = "0xF2fD1B9b262982F12446149A27d8901Ac68dcB59"
+payments_address = "0x6f982192B4D225D67ED52A31308a602438882D6b"
+storage_address = "0xEB383625D7837aD49C1909f74d05a2db247CE0ca"
+users_address = "0x8FBAC8549fe9cb0630f7E30929C8256b9b67E68f"
+token_address = "0x0AabEbf21Cc4591475bb64e105267b3d55C7e0f1"
+mediation_address = "0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"
+jobcreator_address = "0x691ddE4710baFA7D0d7c02da32FeFB513CC870fA"

--- a/pkg/options/deprecation.go
+++ b/pkg/options/deprecation.go
@@ -1,0 +1,26 @@
+package options
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lilypad-tech/lilypad/pkg/data"
+	"github.com/lilypad-tech/lilypad/pkg/web3"
+)
+
+// TODO(bgins) Remove once users have migrated away from old testnet
+func CheckDeprecation(serviceOptions data.ServiceConfig, web3Options web3.Web3Options) {
+	if web3Options.RpcURL == "ws://testnet.lilypad.tech:8546" {
+		web3Options.PrivateKey = "*****"
+		log.SetFlags(0)
+		log.Fatal(fmt.Sprintf(`This testnet has been deprecated. Please remove all environment variables for RPC URL, chain ID, and contract addresses.
+
+Your environment currently contains:
+
+%v
+%v
+The new testnet environment will be set by default, and you will only need to set your private key.
+`, spew.Sdump(web3Options), spew.Sdump(serviceOptions)))
+	}
+}

--- a/pkg/options/job-creator.go
+++ b/pkg/options/job-creator.go
@@ -84,7 +84,7 @@ func CheckJobCreatorOptions(options jobcreator.JobCreatorOptions) error {
 	return nil
 }
 
-func ProcessJobCreatorOptions(options jobcreator.JobCreatorOptions, args []string) (jobcreator.JobCreatorOptions, error) {
+func ProcessJobCreatorOptions(options jobcreator.JobCreatorOptions, args []string, network string) (jobcreator.JobCreatorOptions, error) {
 	name := ""
 	if len(args) == 1 {
 		name = args[0]
@@ -99,20 +99,34 @@ func ProcessJobCreatorOptions(options jobcreator.JobCreatorOptions, args []strin
 		return options, err
 	}
 	options.Offer.Module = moduleOptions
-	newWeb3Options, err := ProcessWeb3Options(options.Web3)
+
+	newWeb3Options, err := ProcessWeb3Options(options.Web3, network)
 	if err != nil {
 		return options, err
 	}
 	options.Web3 = newWeb3Options
+
+	newServicesOptions, err := ProcessServicesOptions(options.Offer.Services, network)
+	if err != nil {
+		return options, err
+	}
+	options.Offer.Services = newServicesOptions
+
 	return options, CheckJobCreatorOptions(options)
 }
 
-func ProcessOnChainJobCreatorOptions(options jobcreator.JobCreatorOptions, args []string) (jobcreator.JobCreatorOptions, error) {
-	newWeb3Options, err := ProcessWeb3Options(options.Web3)
+func ProcessOnChainJobCreatorOptions(options jobcreator.JobCreatorOptions, args []string, network string) (jobcreator.JobCreatorOptions, error) {
+	newWeb3Options, err := ProcessWeb3Options(options.Web3, network)
 	if err != nil {
 		return options, err
 	}
 	options.Web3 = newWeb3Options
+
+	newServicesOptions, err := ProcessServicesOptions(options.Offer.Services, network)
+	if err != nil {
+		return options, err
+	}
+	options.Offer.Services = newServicesOptions
 
 	err = CheckWeb3Options(options.Web3)
 	if err != nil {

--- a/pkg/options/mediator.go
+++ b/pkg/options/mediator.go
@@ -40,11 +40,18 @@ func CheckMediatorOptions(options mediator.MediatorOptions) error {
 	return nil
 }
 
-func ProcessMediatorOptions(options mediator.MediatorOptions) (mediator.MediatorOptions, error) {
-	newWeb3Options, err := ProcessWeb3Options(options.Web3)
+func ProcessMediatorOptions(options mediator.MediatorOptions, network string) (mediator.MediatorOptions, error) {
+	newWeb3Options, err := ProcessWeb3Options(options.Web3, network)
 	if err != nil {
 		return options, err
 	}
 	options.Web3 = newWeb3Options
+
+	newServicesOptions, err := ProcessServicesOptions(options.Services, network)
+	if err != nil {
+		return options, err
+	}
+	options.Services = newServicesOptions
+
 	return options, CheckMediatorOptions(options)
 }

--- a/pkg/options/resource-provider.go
+++ b/pkg/options/resource-provider.go
@@ -122,7 +122,13 @@ func CheckResourceProviderOptions(options resourceprovider.ResourceProviderOptio
 	return nil
 }
 
-func ProcessResourceProviderOfferOptions(options resourceprovider.ResourceProviderOfferOptions) (resourceprovider.ResourceProviderOfferOptions, error) {
+func ProcessResourceProviderOfferOptions(options resourceprovider.ResourceProviderOfferOptions, network string) (resourceprovider.ResourceProviderOfferOptions, error) {
+	newServicesOptions, err := ProcessServicesOptions(options.Services, network)
+	if err != nil {
+		return options, err
+	}
+	options.Services = newServicesOptions
+
 	// if there are no specs then populate with the single spec
 	if len(options.Specs) == 0 {
 		// loop the number of machines we want to offer
@@ -133,13 +139,13 @@ func ProcessResourceProviderOfferOptions(options resourceprovider.ResourceProvid
 	return options, nil
 }
 
-func ProcessResourceProviderOptions(options resourceprovider.ResourceProviderOptions) (resourceprovider.ResourceProviderOptions, error) {
-	newOfferOptions, err := ProcessResourceProviderOfferOptions(options.Offers)
+func ProcessResourceProviderOptions(options resourceprovider.ResourceProviderOptions, network string) (resourceprovider.ResourceProviderOptions, error) {
+	newOfferOptions, err := ProcessResourceProviderOfferOptions(options.Offers, network)
 	if err != nil {
 		return options, err
 	}
 	options.Offers = newOfferOptions
-	newWeb3Options, err := ProcessWeb3Options(options.Web3)
+	newWeb3Options, err := ProcessWeb3Options(options.Web3, network)
 	if err != nil {
 		return options, err
 	}

--- a/pkg/options/services.go
+++ b/pkg/options/services.go
@@ -9,8 +9,8 @@ import (
 
 func GetDefaultServicesOptions() data.ServiceConfig {
 	return data.ServiceConfig{
-		Solver:   GetDefaultServeOptionString("SERVICE_SOLVER", "0x346d811cbb883548252418121f5bb0371eb07049"),
-		Mediator: GetDefaultServeOptionStringArray("SERVICE_MEDIATORS", []string{"0xc66b9b74e307f30e7af79c03fee6ceb8b1ced997"}),
+		Solver:   GetDefaultServeOptionString("SERVICE_SOLVER", ""),
+		Mediator: GetDefaultServeOptionStringArray("SERVICE_MEDIATORS", []string{}),
 	}
 }
 

--- a/pkg/options/services.go
+++ b/pkg/options/services.go
@@ -25,7 +25,20 @@ func AddServicesCliFlags(cmd *cobra.Command, servicesConfig *data.ServiceConfig)
 	)
 }
 
-func ProcessServicesOptions(options data.ServiceConfig) (data.ServiceConfig, error) {
+func ProcessServicesOptions(options data.ServiceConfig, network string) (data.ServiceConfig, error) {
+	config, err := getConfig(network)
+	if err != nil {
+		return options, err
+	}
+
+	// Apply configs when environment variables or command line options are not used
+	if options.Solver == "" {
+		options.Solver = config.ServiceConfig.Solver
+	}
+	if len(options.Mediator) == 0 {
+		options.Mediator = config.ServiceConfig.Mediator
+	}
+
 	return options, nil
 }
 

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -32,8 +32,8 @@ func CheckSolverOptions(options solver.SolverOptions) error {
 	return nil
 }
 
-func ProcessSolverOptions(options solver.SolverOptions) (solver.SolverOptions, error) {
-	newWeb3Options, err := ProcessWeb3Options(options.Web3)
+func ProcessSolverOptions(options solver.SolverOptions, network string) (solver.SolverOptions, error) {
+	newWeb3Options, err := ProcessWeb3Options(options.Web3, network)
 	if err != nil {
 		return options, err
 	}

--- a/pkg/options/web3.go
+++ b/pkg/options/web3.go
@@ -13,12 +13,12 @@ func GetDefaultWeb3Options() web3.Web3Options {
 	return web3.Web3Options{
 
 		// core settings
-		RpcURL:     GetDefaultServeOptionString("WEB3_RPC_URL", "ws://testnet.lilypad.tech:8546"),
+		RpcURL:     GetDefaultServeOptionString("WEB3_RPC_URL", ""),
 		PrivateKey: GetDefaultServeOptionString("WEB3_PRIVATE_KEY", ""),
-		ChainID:    GetDefaultServeOptionInt("WEB3_CHAIN_ID", 1337), //nolint:gomnd
+		ChainID:    GetDefaultServeOptionInt("WEB3_CHAIN_ID", 0), //nolint:gomnd
 
 		// contract addresses
-		ControllerAddress: GetDefaultServeOptionString("WEB3_CONTROLLER_ADDRESS", "0x8e136587e3e5266d5244f6aa896E5CAf8E969946"),
+		ControllerAddress: GetDefaultServeOptionString("WEB3_CONTROLLER_ADDRESS", ""),
 		PaymentsAddress:   GetDefaultServeOptionString("WEB3_PAYMENTS_ADDRESS", ""),
 		StorageAddress:    GetDefaultServeOptionString("WEB3_STORAGE_ADDRESS", ""),
 		UsersAddress:      GetDefaultServeOptionString("WEB3_USERS_ADDRESS", ""),

--- a/pkg/options/web3.go
+++ b/pkg/options/web3.go
@@ -87,7 +87,41 @@ func CheckWeb3Options(options web3.Web3Options) error {
 	return nil
 }
 
-func ProcessWeb3Options(options web3.Web3Options) (web3.Web3Options, error) {
+func ProcessWeb3Options(options web3.Web3Options, network string) (web3.Web3Options, error) {
+	config, err := getConfig(network)
+	if err != nil {
+		return options, err
+	}
+
+	// Apply configs when environment variables or command line options are not used
+	if options.RpcURL == "" {
+		options.RpcURL = config.Web3.RpcURL
+	}
+	if options.ChainID == 0 {
+		options.ChainID = config.Web3.ChainID
+	}
+	if options.ControllerAddress == "" {
+		options.ControllerAddress = config.Web3.ControllerAddress
+	}
+	if options.PaymentsAddress == "" {
+		options.PaymentsAddress = config.Web3.PaymentsAddress
+	}
+	if options.StorageAddress == "" {
+		options.StorageAddress = config.Web3.StorageAddress
+	}
+	if options.UsersAddress == "" {
+		options.UsersAddress = config.Web3.UsersAddress
+	}
+	if options.MediationAddress == "" {
+		options.MediationAddress = config.Web3.MediationAddress
+	}
+	if options.JobCreatorAddress == "" {
+		options.JobCreatorAddress = config.Web3.JobCreatorAddress
+	}
+	if options.TokenAddress == "" {
+		options.TokenAddress = config.Web3.TokenAddress
+	}
+
 	if options.PrivateKey == "" {
 		options.PrivateKey = os.Getenv("WEB3_PRIVATE_KEY")
 	}

--- a/pkg/web3/types.go
+++ b/pkg/web3/types.go
@@ -9,22 +9,22 @@ import (
 type Web3Options struct {
 
 	// core settings
-	RpcURL     string `json:"rpc_url"`
-	PrivateKey string `json:"private_key"`
-	ChainID    int    `json:"chain_id"`
+	RpcURL     string `json:"rpc_url" toml:"rpc_url"`
+	PrivateKey string `json:"private_key" toml:"private_key"`
+	ChainID    int    `json:"chain_id" toml:"chain_id"`
 
 	// contract addresses
-	ControllerAddress string `json:"controller_address"`
-	PaymentsAddress   string `json:"payments_address"`
-	StorageAddress    string `json:"storage_address"`
-	UsersAddress      string `json:"users_address"`
-	MediationAddress  string `json:"mediation_address"`
-	JobCreatorAddress string `json:"jobcreator_address"`
-	TokenAddress      string `json:"token_address"`
+	ControllerAddress string `json:"controller_address" toml:"controller_address"`
+	PaymentsAddress   string `json:"payments_address" toml:"payments_address"`
+	StorageAddress    string `json:"storage_address" toml:"storage_address"`
+	UsersAddress      string `json:"users_address" toml:"users_address"`
+	TokenAddress      string `json:"token_address" toml:"token_address"`
+	MediationAddress  string `json:"mediation_address" toml:"mediation_address"`
+	JobCreatorAddress string `json:"jobcreator_address" toml:"jobcreator_address"`
 
 	// this is injected by whatever service we are running
 	// it's used for logging tx's
-	Service system.Service `json:"-"`
+	Service system.Service `json:"-" toml:"-"`
 }
 
 type EventChannelCollection interface {

--- a/stack
+++ b/stack
@@ -218,7 +218,7 @@ function run-cowsay-onchain() {
 
 function solver() {
   echo "- Reminder to do doppler setup to project->solver and config->dev"
-  doppler run --preserve-env -p solver -c dev -- go run . solver
+  doppler run --preserve-env -p solver -c dev -- go run . solver --network dev
 }
 
 function solver-docker-build() {
@@ -226,6 +226,7 @@ function solver-docker-build() {
     -t solver \
     -f ./docker/solver/Dockerfile \
     --build-arg arch=${OS_ARCH} \
+    --build-arg network=dev \
     .
 }
 
@@ -245,13 +246,14 @@ function solver-docker-run() {
 
 function job-creator() {
   echo "- Reminder to do doppler setup to project->job-creator and config->dev"
-  doppler run --preserve-env -p job-creator -c dev -- go run . jobcreator
+  doppler run --preserve-env -p job-creator -c dev -- go run . jobcreator --network dev
 }
 
 function job-creator-docker-build() {
   docker build \
     -t job-creator \
     -f ./docker/job-creator/Dockerfile \
+    --build-arg network=dev \
     .
 }
 
@@ -270,7 +272,7 @@ function job-creator-docker-run() {
 
 function resource-provider() {
   echo "- Reminder to do doppler setup to project->resource-provider and config->dev"
-  doppler run --preserve-env -p resource-provider -c dev -- go run . resource-provider "$@"
+  doppler run --preserve-env -p resource-provider -c dev -- go run . resource-provider "$@" --network dev
 }
 
 function resource-provider-docker-build() {
@@ -278,6 +280,7 @@ function resource-provider-docker-build() {
     -t resource-provider \
     -f ./docker/resource-provider/Dockerfile \
     --build-arg doppler_config=dev \
+    --build-arg network=dev \
     --build-arg DOPPLER_TOKEN_RESOURCE_PROVIDER="$(doppler configs tokens create -p resource-provider -c dev resource_provider_docker --plain)" \
     .
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/executor/noop"
 	"github.com/lilypad-tech/lilypad/pkg/jobcreator"
@@ -16,7 +17,6 @@ import (
 	solvermemorystore "github.com/lilypad-tech/lilypad/pkg/solver/store/memory"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +59,7 @@ func getResourceProvider(
 	if resourceProviderOptions.Web3.PrivateKey == "" {
 		return nil, fmt.Errorf("RESOURCE_PROVIDER_PRIVATE_KEY is not defined")
 	}
-	resourceProviderOptions, err := optionsfactory.ProcessResourceProviderOptions(resourceProviderOptions)
+	resourceProviderOptions, err := optionsfactory.ProcessResourceProviderOptions(resourceProviderOptions, "dev")
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func getMediator(
 	if mediatorOptions.Web3.PrivateKey == "" {
 		return nil, fmt.Errorf("MEDIATOR_PRIVATE_KEY is not defined")
 	}
-	mediatorOptions, err := optionsfactory.ProcessMediatorOptions(mediatorOptions)
+	mediatorOptions, err := optionsfactory.ProcessMediatorOptions(mediatorOptions, "dev")
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func getJobCreatorOptions(options testOptions) (jobcreator.JobCreatorOptions, er
 	ret, err := optionsfactory.ProcessJobCreatorOptions(jobCreatorOptions, []string{
 		// this should point to the shortcut
 		"cowsay:v0.0.2",
-	})
+	}, "dev")
 
 	if err != nil {
 		return ret, err


### PR DESCRIPTION
### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [x] **Logic** - thorough check (from everybody doing review)

### Summary

This pull request adds a global `--network` command line option that sets default services and web3 options for `testnet`, `devnet`, and `dev` networks. The defaults are pulled from configs embedded into the binary.

### Task/Issue reference

Closes: #131

### Details

The network defaults to `testnet` when the network flag is not used.

The embedded configs apply to `run`, `solver`,  `resource-provider`, `mediator`, and `jobcreator` commands. The following examples use the `run` command as an example.

#### Using Testnet defaults

```sh
go run . run cowsay:v0.0.1 -i Message=moo
```

This command uses the default values from `pkg/options/configs/testnet.toml`

#### Using Devnet defaults

```sh
go run . run cowsay:v0.0.1 -i Message=moo --network devnet
go run . run cowsay:v0.0.1 -i Message=moo -n devnet // shorthand version using -n
```

This command uses the default values from `pkg/options/configs/devnet.toml`

#### Override with an environment variable

```sh
WEB3_RPC_URL=http://example.com go run . run cowsay:v0.0.1 -i Message=moo
```

This command uses the default `testnet` values but overrides the RPC URL.

#### Override with a command line option

```sh
go run . run cowsay:v0.0.1 -i Message=moo --web3-chain-id 1337
```

This command uses the default `testnet` values but overrides the Chain ID.

It is also possible to override with environment variables and command line options at the same time.

### How to test this code?

The last commit on this PR is a temporary commit that prints the web3 environment for each of the commands. We will remove this commit after folks have had a chance to review.

Note that the chain IDs for `dev` and `devnet` are set to `421614` in preparation for our Arbitrum work, but we may need to override them to `1337` for the moment.
