### PR TITLE
feat: Add GCP deprecation notice

### DIFF
--- a/cmd/lilypad/jobcreator.go
+++ b/cmd/lilypad/jobcreator.go
@@ -19,6 +19,8 @@ func newJobCreatorCmd() *cobra.Command {
 		Long:    "Start the lilypad job creator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			optionsfactory.CheckDeprecation(options.Offer.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessOnChainJobCreatorOptions(options, args, network)
 

--- a/cmd/lilypad/mediator.go
+++ b/cmd/lilypad/mediator.go
@@ -21,6 +21,8 @@ func newMediatorCmd() *cobra.Command {
 		Long:    "Start the lilypad mediator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(options.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessMediatorOptions(options, network)
 

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -20,6 +20,8 @@ func newResourceProviderCmd() *cobra.Command {
 		Long:    "Start the lilypad resource-provider service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(options.Offers.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessResourceProviderOptions(options, network)
 

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -27,6 +27,8 @@ func newRunCmd() *cobra.Command {
 		Long:    "Run a job on the Lilypad network.",
 		Example: "run cowsay:v0.0.1 -i Message=moo",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			optionsfactory.CheckDeprecation(options.Offer.Services, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessJobCreatorOptions(options, args, network)
 

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -3,6 +3,7 @@ package lilypad
 import (
 	"fmt"
 
+	"github.com/lilypad-tech/lilypad/pkg/data"
 	optionsfactory "github.com/lilypad-tech/lilypad/pkg/options"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	memorystore "github.com/lilypad-tech/lilypad/pkg/solver/store/memory"
@@ -20,6 +21,8 @@ func newSolverCmd() *cobra.Command {
 		Long:    "Start the lilypad solver service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			optionsfactory.CheckDeprecation(data.ServiceConfig{}, options.Web3)
+
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessSolverOptions(options, network)
 

--- a/pkg/options/deprecation.go
+++ b/pkg/options/deprecation.go
@@ -1,0 +1,26 @@
+package options
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lilypad-tech/lilypad/pkg/data"
+	"github.com/lilypad-tech/lilypad/pkg/web3"
+)
+
+// TODO(bgins) Remove once users have migrated away from old testnet
+func CheckDeprecation(serviceOptions data.ServiceConfig, web3Options web3.Web3Options) {
+	if web3Options.RpcURL == "ws://testnet.lilypad.tech:8546" {
+		web3Options.PrivateKey = "*****"
+		log.SetFlags(0)
+		log.Fatal(fmt.Sprintf(`This testnet has been deprecated. Please remove all environment variables for RPC URL, chain ID, and contract addresses.
+
+Your environment currently contains:
+
+%v
+%v
+The new testnet environment will be set by default, and you will only need to set your private key.
+`, spew.Sdump(web3Options), spew.Sdump(serviceOptions)))
+	}
+}


### PR DESCRIPTION
### Review Type Requested (choose one):

- [ ] **Glance** - superficial check (from domain experts)
- [x] **Logic** - thorough check (from everybody doing review)

### Summary

Adds a check to see if the user is attempting to use the GCP Testnet.

### Task/Issue reference

Implements #131 

### Details

The check is triggered when the GCP RPC endpoint is used. It fatally stops the program and instructs the user how to migrate to the new Testnet.

For example, when the chain ID and GCP RPC endpoint are set:

```
This testnet has been deprecated. Please remove all environment variables for RPC URL, chain ID, and contract addresses.

Your environment currently contains:

(web3.Web3Options) {
 RpcURL: (string) (len=30) "ws://testnet.lilypad.tech:8546",
 PrivateKey: (string) (len=5) "*****",
 ChainID: (int) 1337,
 ControllerAddress: (string) "",
 PaymentsAddress: (string) "",
 StorageAddress: (string) "",
 UsersAddress: (string) "",
 TokenAddress: (string) "",
 MediationAddress: (string) "",
 JobCreatorAddress: (string) "",
 Service: (system.Service) (len=11) "job-creator"
}

(data.ServiceConfig) {
 Solver: (string) "",
 Mediator: ([]string) <nil>
}

The new testnet environment will be set by default, and you will only need to set your private key.
```

### How to test this code?

Run the `run` command in any environment that uses the old endpoint. This can be forced with a command line option:

```sh
go run . run cowsay:v0.0.1 -i Message=moo --web3-rpc-url ws://testnet.lilypad.tech:8546
```
