### PR TITLE
deploy: docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ hardhat/typechain-types
 node_modules/*
 # Ignore the binary executable
 lilypad
+!/docker/lilypad
 !cmd/lilypad
 .env
 *.env

--- a/docker/docker-compose/resource-provider-bacalhau.yml
+++ b/docker/docker-compose/resource-provider-bacalhau.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  lilypad:
+    build: lilypad/
+    container_name: lilypad_compose
+    command: ["/usr/local/bin/lilypad","resource-provider"]
+    environment:
+      - WEB3_PRIVATE_KEY=<Your Private Key>
+      - LOG_TYPE=json
+      - LOG_LEVEL=debug
+      - HOME=/app/lilypad
+      - OFFER_GPU=1
+
+  bacalhau:
+    build: bacalhau/
+    container_name: bacalhau_compose

--- a/docker/lilypad/Dockerfile
+++ b/docker/lilypad/Dockerfile
@@ -1,0 +1,15 @@
+# Using Ubuntu as the base image
+FROM ubuntu:latest
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    curl \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Lilypad
+COPY ./lilypad /usr/local/bin/lilypad
+RUN chmod +x /usr/local/bin/lilypad
+ENV PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
The is the implementation of #93 to give an option to end users and local dev, to pack these resource provider and bacalhau services together.


### Task/Issue reference

Closes: #93 

### Details (optional)
Add any additional details that might help Code Reviewers digest this PR

### How to test this code? (optional)
1. Prepare lilypad folder and bacalhau folder which contains its Dockerfile and the latest binary file, respectively 
2. Prepare docker-compose.yml file for lilypad and bacalha in the same directory of lilypad and bacalhau folder : `mv resource-provider-bacalhau.yml docker-compose.yml `
3. Use Your Private Key to replace the configuration of WEB3_PRIVATE_KEY=<Your Private Key> in docker-compose.yml.
4. Use command `docker compose up -d` to run lilypad and bacalhau service together .

### Anything else? (optional)
NA
