### PR TITLE
feat: add tracking to resource provider

### DIFF
--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -7,6 +7,8 @@ type ServerOptions struct {
 }
 
 type ClientOptions struct {
-	URL        string
-	PrivateKey string
+	URL           string
+	PrivateKey    string
+	PublicAddress string
+	Type          string
 }

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -42,10 +42,13 @@ func NewJobCreatorController(
 		return nil, err
 	}
 
-	solverClient, err := solver.NewSolverClient(http.ClientOptions{
-		URL:        solverUrl,
-		PrivateKey: options.Web3.PrivateKey,
-	})
+	solverClient, err := solver.NewSolverClient(
+		http.ClientOptions{
+			URL:           solverUrl,
+			PrivateKey:    options.Web3.PrivateKey,
+			Type:          "JobCreator",
+			PublicAddress: web3SDK.GetAddress().String(),
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mediator/controller.go
+++ b/pkg/mediator/controller.go
@@ -51,10 +51,13 @@ func NewMediatorController(
 		return nil, err
 	}
 
-	solverClient, err := solver.NewSolverClient(http.ClientOptions{
-		URL:        solverUrl,
-		PrivateKey: options.Web3.PrivateKey,
-	})
+	solverClient, err := solver.NewSolverClient(
+		http.ClientOptions{
+			URL:           solverUrl,
+			PrivateKey:    options.Web3.PrivateKey,
+			Type:          "Mediator",
+			PublicAddress: web3SDK.GetAddress().String(),
+		})
 	if err != nil {
 		log.Error().Msgf("error NewSolverClient")
 		return nil, err

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -49,10 +49,13 @@ func NewResourceProviderController(
 		return nil, err
 	}
 
-	solverClient, err := solver.NewSolverClient(http.ClientOptions{
-		URL:        solverUrl,
-		PrivateKey: options.Web3.PrivateKey,
-	})
+	solverClient, err := solver.NewSolverClient(
+		http.ClientOptions{
+			URL:           solverUrl,
+			PrivateKey:    options.Web3.PrivateKey,
+			Type:          "ResourceProvider",
+			PublicAddress: web3SDK.GetAddress().String(),
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/solver/client.go
+++ b/pkg/solver/client.go
@@ -49,8 +49,9 @@ func (client *SolverClient) Start(ctx context.Context, cm *system.CleanupManager
 			}
 		}
 	}()
+	websocketURL := fmt.Sprintf("%s%s%s%s%s", http.WEBSOCKET_SUB_PATH, "?&Type=", client.options.Type, "&ID=", client.options.PublicAddress)
 	http.ConnectWebSocket(
-		http.WebsocketURL(client.options, http.WEBSOCKET_SUB_PATH),
+		http.WebsocketURL(client.options, websocketURL),
 		websocketEventChannel,
 		ctx,
 	)


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes:
- Add a mechanism to trigger events when the websocket connection is in place and when it disconnects
- Add a payload to the websocket connection to identify the type of service connecting and the public address from it
- Use the mechanism from above to update the number of resource providers connected to the solver
- Use the mechanism from above to track connect/disconnect events
- Track node info when a resource provider connects to the solver

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/lilypad/issues/134

### How to test this code? (optional)

Follow the instructions here to test: https://github.com/Lilypad-Tech/api/pull/40
