### PR TITLE
feat: add geolocation data to websocket events

### DIFF
--- a/pkg/http/websocket_server.go
+++ b/pkg/http/websocket_server.go
@@ -22,8 +22,10 @@ type ConnectionWrapper struct {
 }
 
 type WSConnectionParams struct {
-	ID   string
-	Type string
+	ID          string
+	Type        string
+	CountryCode string
+	IP          string
 }
 
 // StartWebSocketServer starts a WebSocket server
@@ -97,8 +99,10 @@ func StartWebSocketServer(
 		}
 		params := r.URL.Query()
 		connParams := WSConnectionParams{
-			ID:   params.Get("ID"),
-			Type: params.Get("Type"),
+			ID:          params.Get("ID"),
+			Type:        params.Get("Type"),
+			CountryCode: r.Header.Get("Cf-Ipcountry"),
+			IP:          r.Header.Get("Cf-Connecting-Ip"),
 		}
 		defer conn.Close()
 		connectCB(connParams)

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
+	"github.com/lilypad-tech/lilypad/pkg/metricsDashboard"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
@@ -98,6 +99,14 @@ func (controller *JobCreatorController) SubscribeToJobOfferUpdates(sub JobOfferS
 */
 func (controller *JobCreatorController) subscribeToSolver() error {
 	controller.solverClient.SubscribeEvents(func(ev solver.SolverEvent) {
+		if ev.EventType == "DealStateUpdated" {
+			metricsDashboard.TrackDeal(metricsDashboard.DealPayload{
+				ID:               ev.Deal.ID,
+				JobID:            ev.Deal.JobOffer,
+				JobCreator:       ev.Deal.JobCreator,
+				ResourceProvider: ev.Deal.ResourceProvider,
+			})
+		}
 		switch ev.EventType {
 		case solver.DealAdded:
 			if ev.Deal == nil {

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -71,12 +71,21 @@ func TrackNodeInfo(resourceOffer data.ResourceOffer) {
 	TrackEvent(url, payload)
 }
 
-func TrackNodeConnectionEvent(event string, ID string) {
+type NodeConnectionParams struct {
+	Event       string
+	ID          string
+	CountryCode string
+	IP          string
+}
+
+func TrackNodeConnectionEvent(params NodeConnectionParams) {
 	var url = host + nodeConnectionEndpoint
 	data := map[string]interface{}{
-		"ID":    ID,
-		"Event": event,
-		"Time":  time.Now().UnixMilli(),
+		"ID":          params.ID,
+		"Event":       params.Event,
+		"CountryCode": params.CountryCode,
+		"IP":          params.IP,
+		"Time":        time.Now().UnixMilli(),
 	}
 	byts, _ := json.Marshal(data)
 	payload := string(byts)

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -14,6 +14,7 @@ import (
 const jobsEndpoint = "jobs"
 const nodeInfoEndpoint = "nodes"
 const nodeConnectionEndpoint = "uptimes"
+const dealsEndpoint = "deals"
 
 var host = os.Getenv("API_HOST") + "metrics-dashboard/"
 
@@ -88,6 +89,21 @@ func TrackNodeConnectionEvent(params NodeConnectionParams) {
 		"Time":        time.Now().UnixMilli(),
 	}
 	byts, _ := json.Marshal(data)
+	payload := string(byts)
+
+	TrackEvent(url, payload)
+}
+
+type DealPayload struct {
+	ID               string
+	JobCreator       string
+	ResourceProvider string
+	JobID            string
+}
+
+func TrackDeal(params DealPayload) {
+	var url = host + dealsEndpoint
+	byts, _ := json.Marshal(params)
 	payload := string(byts)
 
 	TrackEvent(url, payload)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -337,7 +337,7 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 	return ret, nil
 }
 
-func (controller *SolverController) removeResourceOfferBYResourceProvider(ID string) error {
+func (controller *SolverController) removeResourceOfferByResourceProvider(ID string) error {
 	controller.log.Info("remove resource offer", ID)
 	resourceOffers, err := controller.store.GetResourceOffers(store.GetResourceOffersQuery{
 		ResourceProvider: ID,

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -154,7 +154,7 @@ func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParam
 			CountryCode: connParams.CountryCode,
 			IP:          connParams.IP,
 		})
-		solverServer.controller.removeResourceOfferBYResourceProvider(connParams.ID)
+		solverServer.controller.removeResourceOfferByResourceProvider(connParams.ID)
 	}
 }
 

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -137,13 +137,23 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 // WS connect events
 func (solverServer *solverServer) connectCB(connParams http.WSConnectionParams) {
 	if connParams.Type == "ResourceProvider" {
-		metricsDashboard.TrackNodeConnectionEvent("Connect", connParams.ID)
+		metricsDashboard.TrackNodeConnectionEvent(metricsDashboard.NodeConnectionParams{
+			Event:       "Connect",
+			ID:          connParams.ID,
+			CountryCode: connParams.CountryCode,
+			IP:          connParams.IP,
+		})
 	}
 }
 
 func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParams) {
 	if connParams.Type == "ResourceProvider" {
-		metricsDashboard.TrackNodeConnectionEvent("Disconnect", connParams.ID)
+		metricsDashboard.TrackNodeConnectionEvent(metricsDashboard.NodeConnectionParams{
+			Event:       "Disconnect",
+			ID:          connParams.ID,
+			CountryCode: connParams.CountryCode,
+			IP:          connParams.IP,
+		})
 		solverServer.controller.removeResourceOfferBYResourceProvider(connParams.ID)
 	}
 }


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes add geolocation data to the websocket connection events and add them to the payload sent when tracking node uptimes.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/48

### Details (optional)
Requires: https://github.com/Lilypad-Tech/api/pull/41

### How to test this code? (optional)
Follow the instructions in https://github.com/Lilypad-Tech/api/pull/41 to test these changes
