### PR TITLE
chore: Add PR title validation

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -1,0 +1,27 @@
+name: Validate PR Conventional Commit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/PRConventionalCommits@1.1.0
+        with:
+          task_types: '["fix","feat","refactor","perf","spike","hotfix","revert","chore","docs","test","build"]'
+          custom_labels: >-
+            { "fix": "fix",
+              "feat": "feature",
+              "refactor": "refactor",
+              "perf": "performance",
+              "spike": "spike",
+              "hotfix": "hotfix",
+              "revert": "revert",
+              "chore": "chore",
+              "docs": "documentation",
+              "test": "test",
+              "build": "build"
+            }


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary

This pull request adds a PR title validation GitHub action. The action checks that PR titles use conventional commits from a custom list matching our task types.

The GitHub action also labels PRs based on the task type. The `custom_labels` give us longer form titles for the labels. (These labels are optional, but seem like a nice bonus feature.)

This PR sets the stage for using conventional commits for semantic versioning. We want to validate before merging to `main` to determine the new release version.

### Task/Issue reference

Implements: #168
