### PR TITLE
fix: dockerfile rp bacalhau

### DIFF
--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -1,54 +1,47 @@
-FROM ubuntu:latest
+FROM docker:dind
 WORKDIR /usr/src/app
 
+# Build args
+ARG NETWORK=testnet
+
 # Default environment variables
-ENV LOG_TYPE=json
-ENV LOG_LEVEL=debug
-ENV HOME=/app/lilypad
-ENV BACALHAU_SERVE_IPFS_PATH=/data/ipfs
+ENV LOG_LEVEL=info
 ENV OFFER_GPU=1
 
 # Install necessary dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    curl \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update
+RUN apk add wget
+RUN apk add bash
 
-# Installing Bacalhau
+# Install Bacalhau
 RUN cd /tmp && \
     wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.3.2/bacalhau_v1.3.2_linux_amd64.tar.gz && \
     tar xfv bacalhau_v1.3.2_linux_amd64.tar.gz && \
-    mv bacalhau /usr/bin/bacalhau && \
+    mv bacalhau /usr/local/bin/bacalhau && \
     rm bacalhau_v1.3.2_linux_amd64.tar.gz
-# COPY bacalhau /usr/bin/bacalhau
-# RUN  mkdir -p /app/data/ipfs
 
-# Installing Lilypad
-RUN OSARCH=$(uname -m | awk '{if ($0 ~ /arm64|aarch64/) print "arm64"; else if ($0 ~ /x86_64|amd64/) print "amd64"; else print "unsupported_arch"}') && \
-    OSNAME=$(uname -s | awk '{if ($1 == "Darwin") print "darwin"; else if ($1 == "Linux") print "linux"; else print "unsupported_os"}') && \
-    curl https://api.github.com/repos/lilypad-tech/lilypad/releases/latest | \
-    grep "browser_download_url.*lilypad-$OSNAME-$OSARCH" | \
-    cut -d : -f 2,3 | tr -d \" | wget -qi - -O lilypad && \
-    chmod +x lilypad && \
-    mv lilypad /usr/local/bin/lilypad
+# Build and install Lilypad
+COPY --from=golang:1.22.4-alpine /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
-# COPY lilypad lilypad
-# RUN chmod +x lilypad && \
-#     mv lilypad /usr/local/bin/lilypad
+COPY . .
+RUN go build -v .
+RUN mv lilypad /usr/local/bin
 
 # Add both lilypad and bacalhau executables to PATH
-ENV PATH="/usr/local/bin:/usr/bin:${PATH}"
+ENV PATH="/usr/local/bin:${PATH}"
 
 # Create a startup script to run both services simultaneously
 RUN touch run
-
 RUN echo "#!/bin/bash" >> run
+RUN echo "cat run" >> run
+# Launch docker daemon
+RUN echo "dockerd &" >> run
+RUN echo "while ! docker -v; do sleep 1; done" >> run
 # Launch Bacalhau
-RUN echo "/usr/bin/bacalhau serve --node-type compute,requester --peer none --private-internal-ipfs=false &" >> run
+RUN echo "/usr/local/bin/bacalhau serve --node-type compute,requester --peer none --private-internal-ipfs=false --job-selection-accept-networked &" >> run
 # Launch Lilypad
-RUN echo "/usr/local/bin/lilypad resource-provider &" >> run
+RUN echo "/usr/local/bin/lilypad resource-provider --network ${NETWORK}" >> run
 RUN echo "wait -n" >> run
 RUN chmod +x run
 

--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -7,6 +7,7 @@ ARG NETWORK=testnet
 # Default environment variables
 ENV LOG_LEVEL=info
 ENV OFFER_GPU=1
+ENV BACALHAU_API_HOST="localhost"
 
 # Install necessary dependencies
 RUN apk update

--- a/pkg/executor/bacalhau/bacalhau.go
+++ b/pkg/executor/bacalhau/bacalhau.go
@@ -27,8 +27,12 @@ type BacalhauExecutor struct {
 }
 
 func NewBacalhauExecutor(options BacalhauExecutorOptions) (*BacalhauExecutor, error) {
+	apiHost := ""
+	if options.ApiHost != "DO_NOT_SET" {
+		apiHost = fmt.Sprintf("BACALHAU_API_HOST=%s", options.ApiHost)
+	}
 	bacalhauEnv := []string{
-		fmt.Sprintf("BACALHAU_API_HOST=%s", options.ApiHost),
+		apiHost,
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 	}
 	log.Debug().Msgf("bacalhauEnv: %s", bacalhauEnv)

--- a/stack
+++ b/stack
@@ -214,18 +214,18 @@ function resource-provider-docker-build() {
   docker build \
     -t resource-provider \
     -f ./docker/resource-provider/Dockerfile \
-    --build-arg doppler_config=dev \
-    --build-arg network=dev \
-    --build-arg DOPPLER_TOKEN_RESOURCE_PROVIDER="$(doppler configs tokens create -p resource-provider -c dev resource_provider_docker --plain)" \
+    --build-arg NETWORK=dev \
     .
 }
 
 function resource-provider-docker-run() {
   docker run \
     --rm \
+    --privileged \
     --name resource-provider \
     --add-host localhost:host-gateway \
-    -e DOPPLER_TOKEN_RESOURCE_PROVIDER="$(doppler configs tokens create -p resource-provider -c dev resource_provider_docker --max-age 1m --plain)" \
+    --env-file <(doppler -p resource-provider -c dev secrets download --no-file --format docker) \
+    -e OFFER_GPU=0 \
     resource-provider
 }
 

--- a/stack
+++ b/stack
@@ -226,6 +226,7 @@ function resource-provider-docker-run() {
     --add-host localhost:host-gateway \
     --env-file <(doppler -p resource-provider -c dev secrets download --no-file --format docker) \
     -e OFFER_GPU=0 \
+    -e BACALHAU_API_HOST="DO_NOT_SET" \
     resource-provider
 }
 


### PR DESCRIPTION
### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [x] **Logic** - thorough check (from everybody doing review)

### Summary
These changes make it so that the docker image for the `resource-provider` + `bacalhau` services are packed together into a docker image and jobs can be ran from the cli and onchain.

### Task/Issue reference

Implements: https://github.com/Lilypad-Tech/lilypad/issues/93

### Details (optional)
`bacalhau` runs jobs in docker so the `dind` images is used to be able to execute the docker daemon.

### How to test this code? (optional)

In different terminals:
1. `./stack chain-clean && ./stack chain`
2. `./stack chain-boot`
3. `./stack solver`
4. `./stack job-creator`
5. `./stack resource-provider-docker-build && ./stack resource-provider-docker-run`
6. `./stack run-cowsay-onchain` <- verify the correct result
7. `./stack run cowsay:v0.0.4 -i Message="yay"` <- verify the correct result
8. `./stack integration-tests` <- verify pass ok
