### PR TITLE
fix: check combined outputs for potential errors when getting bacalhau job id

### DIFF
--- a/pkg/executor/bacalhau/bacalhau.go
+++ b/pkg/executor/bacalhau/bacalhau.go
@@ -128,9 +128,16 @@ func (executor *BacalhauExecutor) getJobID(
 	)
 	runCmd.Env = executor.bacalhauEnv
 
-	runOutput, err := runCmd.CombinedOutput()
+	runOutputRaw, err := runCmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("error running command %s -> %s, %s", deal.ID, err.Error(), runOutput)
+		return "", fmt.Errorf("error running command %s -> %s, %s", deal.ID, err.Error(), runOutputRaw)
+	}
+	splitOutputs := strings.Split(string(runOutputRaw), "\n")
+	runOutput := splitOutputs[0]
+	outputError := strings.Join(strings.Fields(strings.Join(splitOutputs[1:], " ")), " ")
+
+	if outputError != "" {
+		return "", fmt.Errorf("error running command %s -> %s, %s", deal.ID, outputError, runOutput)
 	}
 
 	id := strings.TrimSpace(string(runOutput))


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes check the combined output from `bacalhau create --id-only --wait path/to/job/spec` for errors because I noticed that sometimes when the `id` was returned, the rest of the output also contained an error and the code was not checking for it, the rest of the process would execute but there would be no results in the output folder.

### How to test this code? (optional)

I don't think I have a straightforward way to reproduce the error, I noticed the situation when testing this [PR](https://github.com/Lilypad-Tech/lilypad/pull/155), I added a print statement to the `runOutput` var and I noticed the full output also included info to the lines of `could not execute job, not enough nodes` (I'm writing this from memory so if you are testing this bear in mind it may be a bit different) and the whole cli run was executed but the output folder did not include any files.
With these changes the process did return an error in that situation and the RP console showed the error had happened.