### PR TITLE
build: deploy resource provider

### DIFF
--- a/.github/workflows/testnet_deploy_services.yml
+++ b/.github/workflows/testnet_deploy_services.yml
@@ -127,3 +127,67 @@ jobs:
               --name job-creator \
               -e DOPPLER_TOKEN=$TESTNET_DOPPLER_TOKEN_JOB_CREATOR \
               $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest
+
+  resource-provider-build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          context: app
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Resource provider build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_RESOURCE_PROVIDER: ${{ secrets.ECR_REPOSITORY_RESOURCE_PROVIDER }}
+        run: |
+          docker build \
+            -t $ECR_REPOSITORY_RESOURCE_PROVIDER \
+            -f ./docker/resource-provider/Dockerfile \
+            --build-arg="network=testnet" \
+            .
+          docker tag $ECR_REPOSITORY_RESOURCE_PROVIDER:latest $ECR_REGISTRY/$ECR_REPOSITORY_RESOURCE_PROVIDER:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_RESOURCE_PROVIDER:latest
+
+      - name: Resource provider deploy to EC2 instance
+        uses: appleboy/ssh-action@master
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_RESOURCE_PROVIDER: ${{ secrets.ECR_REPOSITORY_RESOURCE_PROVIDER }}
+          WEB3_PRIVATE_KEY_RESOURCE_PROVIDER: ${{ secrets.WEB3_PRIVATE_KEY_RESOURCE_PROVIDER }}
+        with:
+          host: ${{ secrets.TESTNET_EC2_HOST_RESOURCE_PROVIDER }}
+          username: ${{ secrets.TESTNET_EC2_USERNAME_RESOURCE_PROVIDER }}
+          key: ${{ secrets.TESTNET_EC2_PRIVATE_KEY_RESOURCE_PROVIDER }}
+          envs: ECR_REGISTRY, ECR_REPOSITORY_RESOURCE_PROVIDER, WEB3_PRIVATE_KEY_RESOURCE_PROVIDER
+          script_stop: true
+          script: |
+            docker stop resource-provider || true
+            docker rm resource-provider || true
+            aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY
+            docker system prune -af
+            docker pull $ECR_REGISTRY/$ECR_REPOSITORY_RESOURCE_PROVIDER:latest
+            docker run \
+              -d \
+              --privileged \
+              --restart always \
+              --name resource-provider \
+              -e OFFER_GPU=0 \
+              -e BACALHAU_API_HOST="DO_NOT_SET" \
+              -e LOG_LEVEL=debug \
+              -e WEB3_PRIVATE_KEY=$WEB3_PRIVATE_KEY_RESOURCE_PROVIDER \
+              $ECR_REGISTRY/$ECR_REPOSITORY_RESOURCE_PROVIDER:latest

--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -8,6 +8,7 @@ ARG NETWORK=testnet
 ENV LOG_LEVEL=info
 ENV OFFER_GPU=1
 ENV BACALHAU_API_HOST="localhost"
+ENV WEB3_PRIVATE_KEY=""
 
 # Install necessary dependencies
 RUN apk update
@@ -35,14 +36,14 @@ ENV PATH="/usr/local/bin:${PATH}"
 # Create a startup script to run both services simultaneously
 RUN touch run
 RUN echo "#!/bin/bash" >> run
-RUN echo "cat run" >> run
 # Launch docker daemon
 RUN echo "dockerd &" >> run
 RUN echo "while ! docker -v; do sleep 1; done" >> run
+RUN echo "sleep 3" >> run
 # Launch Bacalhau
 RUN echo "/usr/local/bin/bacalhau serve --node-type compute,requester --peer none --private-internal-ipfs=false --job-selection-accept-networked &" >> run
 # Launch Lilypad
-RUN echo "/usr/local/bin/lilypad resource-provider --network ${NETWORK}" >> run
+RUN echo "/usr/local/bin/lilypad resource-provider --network ${NETWORK} &" >> run
 RUN echo "wait -n" >> run
 RUN chmod +x run
 


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes add the deploy script for the testnet CPU resource provider (make sure at least there is one RP that can run `cowsay`)

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/lilypad/issues/141

### Details (optional)
For whatever reason, I could not get this to work with `doppler`, if I injected the doppler envs as a file for run the private key was not used 🤷  so I went with the approach of adding it to the secrets in github.

### How to test this code? (optional)
Tested while I created the PR, if you are reading this, I've already made sure the deploy works and we already have an instance in AWS and I was looking at the solver logs and can verify this deploy incremented the number of resource offers (7 at this time)