### PR TITLE
fix: tracking job offer update events

### DIFF
--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -128,6 +128,7 @@ func (controller *JobCreatorController) subscribeToSolver() error {
 				controller.log.Error("solver event", fmt.Errorf("RP received nil job offer"))
 				return
 			}
+			metricsDashboard.TrackJobOfferUpdate(*ev.JobOffer)
 			for _, sub := range controller.jobOfferSubscriptions {
 				go sub(*ev.JobOffer)
 			}

--- a/pkg/jobcreator/onchain_jobcreator.go
+++ b/pkg/jobcreator/onchain_jobcreator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lilypad-tech/lilypad/pkg/data"
-	"github.com/lilypad-tech/lilypad/pkg/metricsDashboard"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	jobcreatorweb3 "github.com/lilypad-tech/lilypad/pkg/web3/bindings/jobcreator"
@@ -63,8 +62,6 @@ func (jobCreator *OnChainJobCreator) Start(ctx context.Context, cm *system.Clean
 		errorChan <- err
 		return errorChan
 	}
-
-	jobCreator.SubscribeToJobOfferUpdates(metricsDashboard.TrackJobOfferUpdate)
 
 	jobCreator.controller.SubscribeToJobOfferUpdates(func(evOffer data.JobOfferContainer) {
 		if evOffer.State != data.GetAgreementStateIndex("ResultsAccepted") {

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -16,8 +16,9 @@ const nodeInfoEndpoint = "nodes"
 const nodeConnectionEndpoint = "uptimes"
 const dealsEndpoint = "deals"
 
+var host = os.Getenv("API_HOST")
+
 func trackEvent(path string, json string) {
-	var host = os.Getenv("API_HOST")
 	if host == "" {
 		return
 	}


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes make it so that tracking the job offer update is not a subscription to job offer updates but a method call right before the subscriptions are executed.

### Details (optional)
Why?
I wish I knew why the previous way was not working, locally it worked, so the assumption was that it would also work in the deployed infra. 
I have a hypothesis the previous subscription was part of the client code and because the client *should* not have access to the `API_HOST` env var the requests should not have been going out, but as it happens, the doppler settings for `run` did include the `API_HOST` - although, after removing it, locally the events would be still tracked 🤷 .

### How to test this code? (optional)
- Setup a local network
- Spin up the api server
- Trigger both a cli jobn and an onchain job, then run the integration tests
- With each execution verify the `jobs` table in the db has the corresponding job entry (in the api repo:`./stack psql`, then `SELECT * FROM jobs;`)