### PR TITLE
feat: push RP docker image to registry

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -2,11 +2,10 @@ name: Publish Docker Image
 
 on:
   push:
-    # TODO: uncomment this before merge!
-    # branches:
-    #   - "main"
-    # tags:
-    #   - "v*"
+    branches:
+      - "main"
+    tags:
+      - "v*"
 
 jobs:
   docker:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,36 @@
+name: Publish Docker Image
+
+on:
+  push:
+    # TODO: uncomment this before merge!
+    # branches:
+    #   - "main"
+    # tags:
+    #   - "v*"
+
+jobs:
+  docker:
+    name: Push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to the Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/Lilypad-Tech/resource-provider
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/resource-provider/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [x] **Logic** - thorough check (from everybody doing review)

### Summary

This adds a github action workflow to push the docker image for the resource provider to the github packages container registry on main (for `latest`) and versioned tags.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/hni/issues/1

### How to test this code? (optional)

Container available here: https://github.com/Lilypad-Tech/lilypad/pkgs/container/resource-provider
