### PR TITLE
feat: add logger for pow events

### DIFF
--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -11,9 +11,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
-	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/rs/zerolog/log"
 )
 
@@ -321,6 +322,26 @@ func GetRequestBuffer(
 	return &buf, nil
 }
 
+func GenericJSONPostClient(url string, json string) (*http.Response, error) {
+	data := []byte(json)
+	client := &http.Client{Timeout: time.Second * 1}
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Printf("error setting up the request: %s", err)
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("error sending the request: %s", err)
+		return nil, err
+	}
+	resp.Body.Close()
+
+	return resp, nil
+}
+
 func PostRequest[RequestType any, ResultType any](
 	options ClientOptions,
 	path string,
@@ -329,7 +350,7 @@ func PostRequest[RequestType any, ResultType any](
 	var result ResultType
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
-		return result, fmt.Errorf("THIS IS A JOSN ERROR: %s", err.Error())
+		return result, fmt.Errorf("THIS IS A JSON ERROR: %s", err.Error())
 	}
 	return PostRequestBuffer[ResultType](
 		options,

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -28,12 +28,16 @@ func trackEvent(path string, json string) {
 	data := []byte(json)
 
 	client := &http.Client{Timeout: time.Second * 1}
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Printf("error setting up the request: %s", err)
+		return
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("error sending the request: %s", err)
 		return
 	}
 	resp.Body.Close()

--- a/pkg/powLogs/logger.go
+++ b/pkg/powLogs/logger.go
@@ -1,12 +1,10 @@
 package powLogs
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"os"
-	"time"
+
+	"github.com/lilypad-tech/lilypad/pkg/http"
 )
 
 type PowLog struct {
@@ -24,34 +22,14 @@ const eventsEndpoint = "events"
 
 var host = os.Getenv("API_HOST")
 
-func trackEvent(path string, json string) {
+func TrackEvent(data PowLog) {
 	if host == "" {
 		return
 	}
 
-	var url = host + namespace + "/" + path
-
-	data := []byte(json)
-
-	client := &http.Client{Timeout: time.Second * 1}
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
-	if err != nil {
-		fmt.Printf("error setting up the request: %s", err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		fmt.Printf("error sending the request: %s", err)
-		return
-	}
-	resp.Body.Close()
-}
-
-func TrackEvent(data PowLog) {
+	var url = host + namespace + "/" + eventsEndpoint
 	byts, _ := json.Marshal(data)
 	payload := string(byts)
 
-	trackEvent(eventsEndpoint, payload)
+	http.GenericJSONPostClient(url, payload)
 }

--- a/pkg/powLogs/logger.go
+++ b/pkg/powLogs/logger.go
@@ -34,12 +34,16 @@ func trackEvent(path string, json string) {
 	data := []byte(json)
 
 	client := &http.Client{Timeout: time.Second * 1}
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Printf("error setting up the request: %s", err)
+		return
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("error sending the request: %s", err)
 		return
 	}
 	resp.Body.Close()

--- a/pkg/powLogs/logger.go
+++ b/pkg/powLogs/logger.go
@@ -1,0 +1,53 @@
+package powLogs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+type PowLog struct {
+	POWTime string // YYYY-MM-DD HH::MM:ss (triggers are every hour on the hour and randomly within the hour)
+	// t := time.Now(); t.Format(time.RFC3339)
+	Caller   string // cron or rp
+	CallerID string // cron or rp public address
+	Step     string // text instead of numbers, this way we can query by giving a sort order to the events if we know all the steps, and we do not need to reorder all events if we add one in between
+	Payload  string // a json payload
+	Status   string // log/info/warn/error a way to split an event payload into multiple entries to then be able to filter logs
+}
+
+const namespace = "pow-logs"
+const eventsEndpoint = "events"
+
+var host = os.Getenv("API_HOST")
+
+func trackEvent(path string, json string) {
+	if host == "" {
+		return
+	}
+
+	var url = host + namespace + "/" + path
+
+	data := []byte(json)
+
+	client := &http.Client{Timeout: time.Second * 1}
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	resp.Body.Close()
+}
+
+func TrackEvent(data PowLog) {
+	byts, _ := json.Marshal(data)
+	payload := string(byts)
+
+	trackEvent(eventsEndpoint, payload)
+}


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes add the pow logger package to track events on the pow process.

### Task/Issue reference

Implements: https://github.com/Lilypad-Tech/internal/issues/201

### How to test this code? (optional)
- Spin up the api server (this [branch](https://github.com/Lilypad-Tech/api/pull/59))
- Add tracking anywhere (that you know will be executed)
```go
	t := time.Now()
	a := map[string]interface{}{"a": 1}
	b, _ := json.Marshal(a)

	powLogs.TrackEvent(powLogs.PowLog{
		POWTime: t.Format(time.RFC3339),
		Caller:   "rp",
		CallerID: "rp",
		Step:     "test",
		Payload:  string(b),
		Status:   "log",
	})
```
- Trigger and verify the logs get captured