### PR TITLE
fix: clean openzeplin proxy deploy metadata

### DIFF
--- a/stack
+++ b/stack
@@ -116,6 +116,7 @@ function chain-clean(){
   rm -rf $(pwd)/hardhat/cache
   rm -rf $(pwd)/hardhat/deployments/geth
   rm -rf $(pwd)/hardhat/deployments/dev
+  rm -rf $(pwd)/hardhat/.openzeppelin
 }
 
 ############################################################################


### PR DESCRIPTION
### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
The reason integration tests were not working was because chain-clean needed remove metadata associated with proxy deploy.