### PR TITLE
chore: Remove PR labeling

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -9,19 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/PRConventionalCommits@1.1.0
+        uses: ytanikin/PRConventionalCommits@1.2.0
         with:
           task_types: '["fix","feat","refactor","perf","spike","hotfix","revert","chore","docs","test","build"]'
-          custom_labels: >-
-            { "fix": "fix",
-              "feat": "feature",
-              "refactor": "refactor",
-              "perf": "performance",
-              "spike": "spike",
-              "hotfix": "hotfix",
-              "revert": "revert",
-              "chore": "chore",
-              "docs": "documentation",
-              "test": "test",
-              "build": "build"
-            }
+          add_label: false


### PR DESCRIPTION
### Review Type Requested (choose one):

- [x] **Glance** - superficial check (from domain experts)

### Summary

This pull request removes automated PR labeling by the Validate PR Conventional Commit action. We found that it overwrites existing labels which we will need for `release-please` in our upcoming release pipeline.

### Task/Issue reference

Implements: #168 

