### PR TITLE
fix: set api host on embedded configs

### DIFF
--- a/pkg/data/types.go
+++ b/pkg/data/types.go
@@ -85,6 +85,7 @@ const (
 type ServiceConfig struct {
 	Solver   string   `json:"solver" toml:"solver"`
 	Mediator []string `json:"mediator" toml:"mediator"`
+	APIHost  string   `json:"api_host" toml:"api_host"`
 }
 
 // posted to the solver by a job creator

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -54,6 +54,8 @@ func NewJobCreatorController(
 		return nil, err
 	}
 
+	metricsDashboard.Init(options.Offer.Services.APIHost)
+
 	controller := &JobCreatorController{
 		solverClient:          solverClient,
 		options:               options,

--- a/pkg/metricsDashboard/logger.go
+++ b/pkg/metricsDashboard/logger.go
@@ -2,7 +2,6 @@ package metricsDashboard
 
 import (
 	"encoding/json"
-	"os"
 	"time"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
@@ -15,13 +14,24 @@ const nodeConnectionEndpoint = "uptimes"
 const dealsEndpoint = "deals"
 const namespace = "metrics-dashboard"
 
-var host = os.Getenv("API_HOST")
+var host string
+
+type NodeConnectionParams struct {
+	Event       string
+	ID          string
+	CountryCode string
+	IP          string
+}
 
 type DealPayload struct {
 	ID               string
 	JobCreator       string
 	ResourceProvider string
 	JobID            string
+}
+
+func Init(h string) {
+	host = h
 }
 
 func TrackJobOfferUpdate(evOffer data.JobOfferContainer) {
@@ -66,13 +76,6 @@ func TrackNodeInfo(resourceOffer data.ResourceOffer) {
 
 	url := host + namespace + "/" + nodeInfoEndpoint
 	http.GenericJSONPostClient(url, payload)
-}
-
-type NodeConnectionParams struct {
-	Event       string
-	ID          string
-	CountryCode string
-	IP          string
 }
 
 func TrackNodeConnectionEvent(params NodeConnectionParams) {

--- a/pkg/options/configs/dev.toml
+++ b/pkg/options/configs/dev.toml
@@ -1,6 +1,7 @@
 [services]
 solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
+api_host = "http://localhost:8002/"
 
 [web3]
 rpc_url = "ws://localhost:8548"

--- a/pkg/options/configs/devnet.toml
+++ b/pkg/options/configs/devnet.toml
@@ -1,6 +1,7 @@
 [services]
 solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
+api_host = "https://api-devnet.lilypad.tech/"
 
 [web3]
 rpc_url = "wss://devnet-chain-ws.lilypad.tech"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -1,6 +1,7 @@
 [services]
 solver = "0xe05e1b71955da4934938a6b16f97e1db9de6b764"
 mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
+api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
 rpc_url = "wss://arb-sepolia.g.alchemy.com/v2/4PDb7czJf8E6z7ZjhXB0Z5fdU1XaQT0u"

--- a/pkg/options/services.go
+++ b/pkg/options/services.go
@@ -11,6 +11,7 @@ func GetDefaultServicesOptions() data.ServiceConfig {
 	return data.ServiceConfig{
 		Solver:   GetDefaultServeOptionString("SERVICE_SOLVER", ""),
 		Mediator: GetDefaultServeOptionStringArray("SERVICE_MEDIATORS", []string{}),
+		APIHost:  GetDefaultServeOptionString("API_HOST", ""),
 	}
 }
 
@@ -22,6 +23,10 @@ func AddServicesCliFlags(cmd *cobra.Command, servicesConfig *data.ServiceConfig)
 	cmd.PersistentFlags().StringSliceVar(
 		&servicesConfig.Mediator, "service-mediators", servicesConfig.Mediator,
 		`The mediators we trust (SERVICE_MEDIATORS)`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&servicesConfig.APIHost, "api-host", servicesConfig.APIHost,
+		`The api host to connect to (API_HOST)`,
 	)
 }
 
@@ -38,6 +43,9 @@ func ProcessServicesOptions(options data.ServiceConfig, network string) (data.Se
 	if len(options.Mediator) == 0 {
 		options.Mediator = config.ServiceConfig.Mediator
 	}
+	if options.APIHost == "" {
+		options.APIHost = config.ServiceConfig.APIHost
+	}
 
 	return options, nil
 }
@@ -48,6 +56,9 @@ func CheckServicesOptions(options data.ServiceConfig) error {
 	}
 	if len(options.Mediator) == 0 {
 		return fmt.Errorf("No mediators services specified - please use SERVICE_MEDIATORS or --service-mediators")
+	}
+	if len(options.APIHost) == 0 {
+		return fmt.Errorf("No api host specified - please use API_HOST or --api-host")
 	}
 	return nil
 }

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -8,8 +8,9 @@ import (
 
 func NewSolverOptions() solver.SolverOptions {
 	options := solver.SolverOptions{
-		Server: GetDefaultServerOptions(),
-		Web3:   GetDefaultWeb3Options(),
+		Server:   GetDefaultServerOptions(),
+		Web3:     GetDefaultWeb3Options(),
+		Services: GetDefaultServicesOptions(),
 	}
 	options.Web3.Service = system.SolverService
 	return options
@@ -18,6 +19,7 @@ func NewSolverOptions() solver.SolverOptions {
 func AddSolverCliFlags(cmd *cobra.Command, options *solver.SolverOptions) {
 	AddWeb3CliFlags(cmd, &options.Web3)
 	AddServerCliFlags(cmd, &options.Server)
+	AddServicesCliFlags(cmd, &options.Services)
 }
 
 func CheckSolverOptions(options solver.SolverOptions) error {

--- a/pkg/powLogs/logger.go
+++ b/pkg/powLogs/logger.go
@@ -2,7 +2,6 @@ package powLogs
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
@@ -22,7 +21,11 @@ const namespace = "pow-logs"
 const eventsEndpoint = "events"
 const hashrateEndpoint = "hashrates"
 
-var host = os.Getenv("API_HOST")
+var host string
+
+func Init(h string) {
+	host = h
+}
 
 func TrackEvent(data PowLog) {
 	if host == "" {

--- a/pkg/resourceprovider/resourceprovider.go
+++ b/pkg/resourceprovider/resourceprovider.go
@@ -91,6 +91,7 @@ func NewResourceProvider(
 		options:    options,
 		web3SDK:    web3SDK,
 	}
+	powLogs.Init(options.Offers.Services.APIHost)
 	return solver, nil
 }
 

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -24,18 +24,23 @@ type solverServer struct {
 	options    http.ServerOptions
 	controller *SolverController
 	store      store.SolverStore
+	services   data.ServiceConfig
 }
 
 func NewSolverServer(
 	options http.ServerOptions,
 	controller *SolverController,
 	store store.SolverStore,
+	services data.ServiceConfig,
 ) (*solverServer, error) {
 	server := &solverServer{
 		options:    options,
 		controller: controller,
 		store:      store,
 	}
+
+	metricsDashboard.Init(services.APIHost)
+
 	return server, nil
 }
 

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"context"
 
+	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
@@ -11,8 +12,9 @@ import (
 )
 
 type SolverOptions struct {
-	Web3   web3.Web3Options
-	Server http.ServerOptions
+	Web3     web3.Web3Options
+	Server   http.ServerOptions
+	Services data.ServiceConfig
 }
 
 type Solver struct {
@@ -32,7 +34,7 @@ func NewSolver(
 	if err != nil {
 		return nil, err
 	}
-	server, err := NewSolverServer(options.Server, controller, store)
+	server, err := NewSolverServer(options.Server, controller, store, options.Services)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
These changes make it so that there is a new embedded config in the services category for the `api host`, this is required for the services to be able to send data to the `api`and it is simpler to add this to the embed instead of asking all RPs to add an `env` file and source it when they run the service.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/147

### Details (optional)
I added the config in the services category, I could be swayed into adding it elsewhere (most prob a new category which I'd call somewhere in line with `services` so it made sense to add there). I did have to add the services flags/options to the solver which will only use 1 out of 3, I do feel this is good enough for now, unless you (the reviewer) have strong reasons why this should be on a different flag/options category.
I went with the route of `Init`ing the logger services instead of instancing them because it felt too much to have to keep the instance around in the services using the loggers.
[Reference](https://discord.com/channels/1212897693450641498/1212898458885685308/1261009219629486121) to the discussion about this task.

### How to test this code? (optional)
- Spin up a network (get ahold of a GPU RP)
- Spin up an api server
- Spin up a cron server
- Verify you get node info and connect events when you run the resource provider service
- Trigger a cli job and verify you get the deal and job events
- Trigger a pow round and verify you get the hashrates events