### PR TITLE
fix: correct pow flag handling in Cobra

### DIFF
--- a/cmd/lilypad/pow_signal.go
+++ b/cmd/lilypad/pow_signal.go
@@ -18,10 +18,15 @@ func newPowSignalCmd() *cobra.Command {
 		Long:    "Send a pow signal to smart contract.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			network, _ := cmd.Flags().GetString("network")
+			network, err := cmd.Flags().GetString("network")
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to retrieve 'network' flag")
+				return err
+			}
 
 			options, err := optionsfactory.ProcessPowSignalOptions(options, network)
 			if err != nil {
+				log.Error().Err(err).Msg("Failed to process PowSignal options")
 				return err
 			}
 			return runPowSignal(cmd, options)
@@ -39,6 +44,7 @@ func runPowSignal(cmd *cobra.Command, options options.PowSignalOptions) error {
 
 	web3SDK, err := web3.NewContractSDK(options.Web3)
 	if err != nil {
+		log.Error().Err(err).Msg("Failed to initialize Web3 SDK")
 		return err
 	}
 
@@ -46,6 +52,6 @@ func runPowSignal(cmd *cobra.Command, options options.PowSignalOptions) error {
 	if err != nil {
 		return err
 	}
-	log.Info().Msgf("send pow signal successful.")
+	log.Info().Msg("Send pow signal successful.")
 	return nil
 }

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -25,6 +25,9 @@ func NewRootCmd() *cobra.Command {
 	var network string
 	RootCmd.PersistentFlags().StringVarP(&network, "network", "n", "testnet", "Sets a target network configuration")
 
+	var powSignalCmd bool
+	RootCmd.PersistentFlags().BoolVarP(&powSignalCmd, "pow-signal", "", false, "Send a pow signal to smart contract")
+
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())
 	RootCmd.AddCommand(newPowSignalCmd())

--- a/pkg/options/resource-provider.go
+++ b/pkg/options/resource-provider.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/resourceprovider"
@@ -106,7 +107,8 @@ func AddResourceProviderPowCliFlags(cmd *cobra.Command, options *resourceprovide
 		&options.CudaHashsPerThread, "cuda-hash-per-thread", options.CudaHashsPerThread,
 		`Cuda hash per threads (CUDA_HASH_PER_THREAD)`,
 	)
-
+	// Explicitly parse flags for the CLI options
+	cmd.ParseFlags(os.Args)
 }
 
 func AddResourceProviderCliFlags(cmd *cobra.Command, options *resourceprovider.ResourceProviderOptions) {


### PR DESCRIPTION
This fix is in relation to issue 21 located [here](https://github.com/Lilypad-Tech/hni/issues/21). These changes needed to be made because the proof of work flag(--enable-allowlist) was not correctly working. The boolean value was being set to true or "on" even when the flag was used. 

- To fix this, I added command to parse the flags value within the Cobra ProofOfWork signal located in /cmd/lilypad/pow_signal.go. After testing, I have verified that the fix works! 

- This is also important because this parsing problem was stepping on other bool values within our Cobra configuration setting the module-allowlist to true or "on" all the time. Being able to turn our flags on and off in cobra is super important!  

### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)
- [x] **Logic** - thorough check (from everybody doing review)

### Summary
Provide a one line summary and link to any relevant references

### Task/Issue reference

Closes: add_link_here

### Details (optional)
Add any additional details that might help Code Reviewers digest this PR

### How to test this code? (optional)

### Anything else? (optional)
