### PR TITLE
chore: Update validate PR title event trigger

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -3,6 +3,8 @@ name: Validate PR Conventional Commit
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
### Review Type Requested (choose one):

- [x] **Glance** - superficial check (from domain experts)

### Summary

This pull request makes the following changes:

- [x] Update the `Validate PR Conventional Commit` workflow to run on `pull_request_target`

### Details

Our `Validate PR Conventional Commit` workflow currently run on `pull_request`, but it fails to run for external contributors. See https://github.com/Lilypad-Tech/lilypad/actions/runs/10114327531/job/27975130888 for example.

GitHub actions can also be triggered by a `pull_request_target` event. According to https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks:

> we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request.

The change in this PR should be enable action runs from external contributors. 

### How to test this code?

Change the title of this PR to `build: Update validate PR title event trigger`. This should trigger the `Validate PR Conventional Commit` workflow.

We will test with an external contributor in #260 once we have merged this PR.
