### PR TITLE
chore: remove DisablePow from PersistentFlags

### DIFF
--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -25,9 +25,6 @@ func NewRootCmd() *cobra.Command {
 	var network string
 	RootCmd.PersistentFlags().StringVarP(&network, "network", "n", "testnet", "Sets a target network configuration")
 
-	var powSignalCmd bool
-	RootCmd.PersistentFlags().BoolVarP(&powSignalCmd, "pow-signal", "", false, "Send a pow signal to smart contract")
-
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())
 	RootCmd.AddCommand(newPowSignalCmd())


### PR DESCRIPTION
This fix is related to issue #261 - Gorka brought up not having the pow-signal set as a PersistentFlag. The cmd does not shouldn't need to be accessible to the other services as described here: https://github.com/Lilypad-Tech/lilypad/pull/261#discussion_r1695150837. 

I have removed the --disable-pow from the persistent flags and recorded a video of the disable-pow true/false value being displayed in a print statement. 

https://github.com/user-attachments/assets/455a94a0-9503-461e-9927-2e9924e6820f

- To startup the RP with POW on, you use `./stack resource-provider`
- To startup the RP with the POW off, you use `./stack resource-provider --disable-pow`

### Review Type Requested (choose one):
- [ ] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary
Provide a one line summary and link to any relevant references

### Task/Issue reference

Closes: add_link_here

### Details (optional)
There was a previous PR here where the parsing cmd was added to fix the pow flag - making it work correctly

Previous PR modifications: https://github.com/Lilypad-Tech/lilypad/pull/261/commits/380f590ed9ff4204144feb9be791dbffd31ca9e4

Original Issue Here: https://github.com/Lilypad-Tech/hni/issues/21

### How to test this code? (optional)
Startup the services and run `./stack resource-provider --disable-pow` to run the RP without POW being executed. 
### Anything else? (optional)
