### PR TITLE
chore: Remove PR title labeling

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -12,16 +12,4 @@ jobs:
         uses: ytanikin/PRConventionalCommits@1.2.0
         with:
           task_types: '["fix","feat","refactor","perf","spike","hotfix","revert","chore","docs","test","build"]'
-          custom_labels: >-
-            { "fix": "fix",
-              "feat": "feature",
-              "refactor": "refactor",
-              "perf": "performance",
-              "spike": "spike",
-              "hotfix": "hotfix",
-              "revert": "revert",
-              "chore": "chore",
-              "docs": "documentation",
-              "test": "test",
-              "build": "build"
-            }
+          add_label: false


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)

### Summary

This pull request makes the following changes:

- [x] Remove PR labeling based on title

The labeling unfortunately removes existing labels. We have experimented with `ytanikin/PRConventionalCommits` at version `v1.2.0` (https://github.com/Lilypad-Tech/lilypad/pull/260), but found that it removed a `documentation` label from https://github.com/Lilypad-Tech/lilypad/pull/265 when it ran the workflow with labeling enabled. 