### PR TITLE
revert: "chore: Remove PR title labeling (#267)"

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -12,4 +12,16 @@ jobs:
         uses: ytanikin/PRConventionalCommits@1.2.0
         with:
           task_types: '["fix","feat","refactor","perf","spike","hotfix","revert","chore","docs","test","build"]'
-          add_label: false
+          custom_labels: >-
+            { "fix": "fix",
+              "feat": "feature",
+              "refactor": "refactor",
+              "perf": "performance",
+              "spike": "spike",
+              "hotfix": "hotfix",
+              "revert": "revert",
+              "chore": "chore",
+              "docs": "documentation",
+              "test": "test",
+              "build": "build"
+            }


### PR DESCRIPTION
### Review Type Requested (choose one):

- [x] **Glance** - superficial check (from domain experts)


### Summary

The pull request reverts a change that removed PR title labeling. Our analysis for the behavior of the relabeling was incorrect: https://github.com/Lilypad-Tech/lilypad/pull/260#issuecomment-2258806804
