### PR TITLE
chore: limit docker log size

### DIFF
--- a/.github/workflows/devnet_deploy.yml
+++ b/.github/workflows/devnet_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          mask-password: 'true'
+          mask-password: "true"
 
       - name: Solver build, tag, and push image to Amazon ECR
         id: build-image
@@ -61,6 +61,7 @@ jobs:
               -d \
               --restart always \
               --name solver \
+              --log-opt max-size=100m \
               -e DOPPLER_TOKEN=$DEVNET_DOPPLER_TOKEN_SOLVER \
               $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
 
@@ -84,7 +85,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          mask-password: 'true'
+          mask-password: "true"
 
       - name: Job creator build, tag, and push image to Amazon ECR
         id: build-image
@@ -122,5 +123,6 @@ jobs:
               -d \
               --restart always \
               --name job-creator \
+              --log-opt max-size=100m \
               -e DOPPLER_TOKEN=$DEVNET_DOPPLER_TOKEN_JOB_CREATOR \
               $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest

--- a/.github/workflows/testnet_deploy_services.yml
+++ b/.github/workflows/testnet_deploy_services.yml
@@ -3,7 +3,7 @@ name: Deploy Testnet services
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   solver-build-deploy:
@@ -25,7 +25,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          mask-password: 'true'
+          mask-password: "true"
 
       - name: Solver build, tag, and push image to Amazon ECR
         id: build-image
@@ -64,6 +64,7 @@ jobs:
               -d \
               --restart always \
               --name solver \
+              --log-opt max-size=100m \
               -e DOPPLER_TOKEN=$TESTNET_DOPPLER_TOKEN_SOLVER \
               $ECR_REGISTRY/$ECR_REPOSITORY_SOLVER:latest
 
@@ -87,7 +88,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          mask-password: 'true'
+          mask-password: "true"
 
       - name: Job creator build, tag, and push image to Amazon ECR
         id: build-image
@@ -125,6 +126,7 @@ jobs:
               -d \
               --restart always \
               --name job-creator \
+              --log-opt max-size=100m \
               -e DOPPLER_TOKEN=$TESTNET_DOPPLER_TOKEN_JOB_CREATOR \
               $ECR_REGISTRY/$ECR_REPOSITORY_JOB_CREATOR:latest
 
@@ -147,7 +149,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          mask-password: 'true'
+          mask-password: "true"
 
       - name: Resource provider build, tag, and push image to Amazon ECR
         id: build-image
@@ -187,6 +189,7 @@ jobs:
               --privileged \
               --restart always \
               --name resource-provider \
+              --log-opt max-size=100m \
               -e OFFER_GPU=0 \
               -e BACALHAU_API_HOST="DO_NOT_SET" \
               -e LOG_LEVEL=debug \


### PR DESCRIPTION
### Review Type Requested (choose one):
- [x] **Glance** - superficial check (from domain experts)

### Summary
For testnet/devenet deploys, we want to limit the size of docker logs (to prevent filling disks)
