### PR TITLE
chore: Ignore Hardhat Openzeppelin outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 hardhat/node_modules
+hardhat/.openzeppelin
 hardhat/artifacts
 hardhat/cache
 hardhat/deployments/dev


### PR DESCRIPTION
### Review Type Requested (choose one):

- [x] **Glance** - superficial check (from domain experts)

### Summary

Per a discussion with @alvin-reyes, the generated outputs in `hardhat/.openzeppelin` can be ignored. These outputs will be regenerated when we run hardhat deployments locally.

