### PR TITLE
chore: add issues_templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name:  "\U0001F41E Bug report"
+description: Report an issue with Lilypad
+labels: ['triage: bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug. If you intend to submit a pull request for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide instructions for reproducing the bug. If the report is vague and has no reproduction, it may take the Lilypad team time to triage the issue. We may ask you for more details or close the issue if we cannot reproduce.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Please include logs around the time this bug occurred. Skip this section if logs are included in the reproduction. Please do not insert an image of logs, but instead copy-paste the log text.
+      render: shell
+  - type: textarea
+    id: Screenshots
+    attributes:
+      label: Screenshots
+      description: Please include screenshots of info that is relevant to this issue.
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Please provide details about the hardware and software (Lilypad Version, OS, OS version, Architecture) in use when the bug occured. Resource providers should also include Bacalhau version and GPU information.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue
+      options:
+        - Annoyance
+        - Blocking an upgrade
+        - Blocking all Lilypad usage
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord Chat
+    url: https://discord.com/channels/1212897693450641498/1230231823674642513
+    about: Ask questions and discuss with other Lilypad RPs and users in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name:  "✨ Feature Request"
+description: Request a new Lilypad feature
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request this feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the proposed solution
+      description: Please provide a clear and concise description of what you would like to happen.
+      placeholder: I would like to see...
+    validations:
+      required: true
+  - type: dropdown
+    id: importance
+    attributes:
+      label: Importance
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Would make my life easier
+        - I cannot use Lilypad without it
+    validations:
+      required: true


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

Added ISSUES_TEMPLATES folder to .github folder
- Added config.yml, Bug_report.yml, and feature_request.yml to the ISSUES_TEMPLATES folder

This is the first PR of 2 for the Lilypad OSS in this repo. The second PR will include the Lilypad contribution guide.

### Task/Issue reference

https://github.com/Lilypad-Tech/lilypad/issues/173

### Test plan

This issues setup has been tested in [this](https://github.com/galaxyxtwo/testContributionGuide) personal repo.
