### PR TITLE
chore: Fix cla-bot config

### DIFF
--- a/.cla-bot
+++ b/.cla-bot
@@ -1,6 +1,0 @@
-{
-  "contributors": [
-
-  ],
-  "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please open a new pull request and sign the Contributor License Agreement following the instructions in our [contributing guide](https://github.com/Lilypad-Tech/test-cla-bot/blob/main/Contributing.md#contributor-license-agreement). Once the pull request is merged, ping a maintainer who will summon me again."
-}

--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,6 @@
+{
+  "contributors": [
+
+  ],
+  "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please open a new pull request and sign the Contributor License Agreement following the instructions in our [contributing guide](https://github.com/Lilypad-Tech/lilypad/blob/main/CONTRIBUTING.md#contributor-license-agreement). Once the pull request is merged, ping a maintainer who will summon me again."
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ This [guide](https://vanjacosic.com/posts/sign-your-git-commits-using-ssh-keys/#
 
 We require all code contributors to sign a contributor license agreement (CLA) that grants license on contributions to Lilypad and Lilypad users. Agreement to the contributor license agreement does not restrict usage of contributions outside of this repository. See [CLA.md](CLA.md) for more details.
 
-To sign the CLA, open a pull request that adds a license accpetance entry to [NOTICES.md](NOTICES.md) and adds your GitHub username to the contributors list in [.cla-bot](.cla-bot). All commits on the pull request must be signed as described in [Signed commits](CONTRIBUTING.md#signed-commits) section of this document.
+To sign the CLA, open a pull request that adds a license accpetance entry to [NOTICES.md](NOTICES.md) and adds your GitHub username to the contributors list in [.clabot](.clabot). All commits on the pull request must be signed as described in [Signed commits](CONTRIBUTING.md#signed-commits) section of this document.
 
 We will review the pull request and add you as a contributor. Agreement to the CLA is required before we merge other contributions.
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Rename `.cla-bot` -> `.clabot`
- [x] Fix link to contributing guide

The name for the `cla-bot` config should be `.clabot`. (https://colineberhardt.github.io/cla-bot/#installing-cla-bot)

### Task/Issue reference

Implements: #173