### PR TITLE
chore: Update lilypad-releases[bot] CLA

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -3,7 +3,7 @@
     "bgins",
     "walkah",
     "narbs91",
-    "lilypad-releases"
+    "lilypad-releases[bot]"
   ],
   "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please open a new pull request and sign the Contributor License Agreement following the instructions in our [contributing guide](https://github.com/Lilypad-Tech/lilypad/blob/main/CONTRIBUTING.md#contributor-license-agreement). Once the pull request is merged, ping a maintainer who will summon me again."
 }

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -23,9 +23,3 @@ Licensee’s name: Narbeh Shahnazarian
 Repository system identifier: narbs91
 
 ---------------------------------------------------------------------------------
-
-Licensee’s name: lilypad-releases
-
-Repository system identifier: lilypad-releases
-
----------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] `lilypad-releases` -> `lilypad-releases[bot]` in CLA contributors list
- [x] Remove `lilypad-releases` from notices

The `cla-bot` GitHub app only checks the contributors list in `.clabot`.

### Related issues or PRs (optional)

Unblocks #320 
