### PR TITLE
chore: Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Lilypad-Tech/lilypad-core-engineering


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add Lilypad engineering team as code owners

We want to request review from the Lilypad engineering team for all pull requests.

### Task/Issue reference

Closes: #327 

### Test plan

Once merged, the engineering team should be pinged on the next PR against `main`.
