### PR TITLE
feat: Add deal making trace

### DIFF
--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -33,12 +33,28 @@ func GetJobOfferID(offer JobOffer) (string, error) {
 	return CalculateCID(offer)
 }
 
+func GetJobOfferContainerIDs(jobOffers []JobOfferContainer) []string {
+	var ids []string
+	for _, offer := range jobOffers {
+		ids = append(ids, offer.ID)
+	}
+	return ids
+}
+
 func GetResourceOfferID(offer ResourceOffer) (string, error) {
 	offer.ID = ""
 	return CalculateCID(offer)
 }
 
 func GetResourceOfferIDs(resourceOffers []ResourceOffer) []string {
+	var ids []string
+	for _, offer := range resourceOffers {
+		ids = append(ids, offer.ID)
+	}
+	return ids
+}
+
+func GetResourceOfferContainerIDs(resourceOffers []ResourceOfferContainer) []string {
 	var ids []string
 	for _, offer := range resourceOffers {
 		ids = append(ids, offer.ID)

--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -38,6 +38,14 @@ func GetResourceOfferID(offer ResourceOffer) (string, error) {
 	return CalculateCID(offer)
 }
 
+func GetResourceOfferIDs(resourceOffers []ResourceOffer) []string {
+	var ids []string
+	for _, offer := range resourceOffers {
+		ids = append(ids, offer.ID)
+	}
+	return ids
+}
+
 func GetDealID(deal Deal) (string, error) {
 	deal.ID = ""
 	return CalculateCID(deal)

--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -43,6 +43,14 @@ func GetDealID(deal Deal) (string, error) {
 	return CalculateCID(deal)
 }
 
+func GetDealIDs(deals []Deal) []string {
+	var ids []string
+	for _, deal := range deals {
+		ids = append(ids, deal.ID)
+	}
+	return ids
+}
+
 func GetModuleID(module ModuleConfig) (string, error) {
 	return CalculateCID(module)
 }

--- a/pkg/options/resource-provider.go
+++ b/pkg/options/resource-provider.go
@@ -46,7 +46,7 @@ func GetDefaultResourceProviderOfferOptions() resourceprovider.ResourceProviderO
 		// this can be populated by a config file
 		Specs: []data.MachineSpec{},
 		// if an RP wants to only run certain modules they list them here
-		// XXX SECURITY: enforce that they are specified with specific git hashes!
+		// XXX SECURITY: enforce that they are specified by CID
 		Modules: GetDefaultServeOptionStringArray("OFFER_MODULES", []string{}),
 		// this is the default pricing mode for an RP
 		Mode: GetDefaultPricingMode(data.FixedPrice),

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -275,13 +275,12 @@ func (controller *SolverController) registerAsSolver() error {
 */
 
 func (controller *SolverController) solve(ctx context.Context) error {
-	// Start solve trace
 	ctx, span := controller.tracer.Start(ctx, "solve")
 	defer span.End()
 
 	// find out which deals we can make from matching the offers
 	span.AddEvent("get_matching_deals.start")
-	deals, err := matcher.GetMatchingDeals(controller.store, controller.updateJobOfferState)
+	deals, err := matcher.GetMatchingDeals(ctx, controller.store, controller.updateJobOfferState, controller.tracer)
 	if err != nil {
 		span.SetStatus(codes.Error, "get matching deals failed")
 		span.RecordError(err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -14,6 +14,8 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/mediation"
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/storage"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -107,7 +109,7 @@ func (controller *SolverController) Start(ctx context.Context, cm *system.Cleanu
 		ctx,
 		CONTROL_LOOP_INTERVAL,
 		func() error {
-			err := controller.solve()
+			err := controller.solve(ctx)
 			if err != nil {
 				errorChan <- err
 			}
@@ -272,20 +274,35 @@ func (controller *SolverController) registerAsSolver() error {
  *
 */
 
-func (controller *SolverController) solve() error {
+func (controller *SolverController) solve(ctx context.Context) error {
+	// Start solve trace
+	ctx, span := controller.tracer.Start(ctx, "solve")
+	defer span.End()
+
 	// find out which deals we can make from matching the offers
+	span.AddEvent("get_matching_deals.start")
 	deals, err := matcher.GetMatchingDeals(controller.store, controller.updateJobOfferState)
 	if err != nil {
+		span.SetStatus(codes.Error, "get matching deals failed")
+		span.RecordError(err)
 		return err
 	}
+	span.AddEvent("get_matching_deals.done")
+	span.SetAttributes(attribute.KeyValue{
+		Key:   "deal_ids",
+		Value: attribute.StringSliceValue(data.GetDealIDs(deals)),
+	})
 
 	// loop over each of the deals add add them to the store and emit events
+	span.AddEvent("add_deals.start")
 	for _, deal := range deals {
 		_, err := controller.addDeal(deal)
 		if err != nil {
 			return err
 		}
 	}
+	span.AddEvent("add_deals.done")
+
 	return nil
 }
 

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -338,7 +338,7 @@ func logMatch(result matchResult) {
 	case marketPriceUnavailable:
 		log.Trace().
 			Str("resource offer", r.resourceOffer.ID).
-			Str("job offer", r.jobOffer.ID).
+			Str("pricing mode", string(r.resourceOffer.Mode)).
 			Msg(r.message())
 	case priceMismatch:
 		log.Trace().

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -123,16 +123,17 @@ func matchOffers(
 		}
 	}
 
+	moduleID, err := data.GetModuleID(jobOffer.Module)
+	if err != nil {
+		return &moduleIDError{
+			jobOffer:      jobOffer,
+			resourceOffer: resourceOffer,
+			err:           err,
+		}
+	}
+
 	// if the resource provider has specified modules then check them
 	if len(resourceOffer.Modules) > 0 {
-		moduleID, err := data.GetModuleID(jobOffer.Module)
-		if err != nil {
-			return &moduleIDError{
-				jobOffer:      jobOffer,
-				resourceOffer: resourceOffer,
-				err:           err,
-			}
-		}
 		// if the resourceOffer.Modules array does not contain the moduleID then we don't match
 		hasModule := false
 		for _, module := range resourceOffer.Modules {

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -1,15 +1,18 @@
 package matcher
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type matchResult interface {
 	matched() bool
 	message() string
+	attributes() []attribute.KeyValue
 }
 
 type offersMatched struct {
@@ -19,6 +22,13 @@ type offersMatched struct {
 
 func (_ offersMatched) matched() bool   { return true }
 func (_ offersMatched) message() string { return "offers matched" }
+func (result offersMatched) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+	}
+}
 
 type cpuMismatch struct {
 	resourceOffer data.ResourceOffer
@@ -27,6 +37,15 @@ type cpuMismatch struct {
 
 func (_ cpuMismatch) matched() bool   { return false }
 func (_ cpuMismatch) message() string { return "did not match CPU" }
+func (result cpuMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.Int("match_result.job_offer.spec.cpu", result.jobOffer.Spec.CPU),
+		attribute.Int("match_result.resource_offer.spec.cpu", result.resourceOffer.Spec.CPU),
+	}
+}
 
 type gpuMismatch struct {
 	resourceOffer data.ResourceOffer
@@ -35,6 +54,15 @@ type gpuMismatch struct {
 
 func (_ gpuMismatch) matched() bool   { return false }
 func (_ gpuMismatch) message() string { return "did not match GPU" }
+func (result gpuMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.Int("match_result.job_offer.spec.gpu", result.jobOffer.Spec.GPU),
+		attribute.Int("match_result.resource_offer.spec.gpu", result.resourceOffer.Spec.GPU),
+	}
+}
 
 type ramMismatch struct {
 	resourceOffer data.ResourceOffer
@@ -43,6 +71,15 @@ type ramMismatch struct {
 
 func (_ ramMismatch) matched() bool   { return false }
 func (_ ramMismatch) message() string { return "did not match RAM" }
+func (result ramMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.Int("match_result.job_offer.spec.ram", result.jobOffer.Spec.RAM),
+		attribute.Int("match_result.resource_offer.spec.ram", result.resourceOffer.Spec.RAM),
+	}
+}
 
 type moduleIDError struct {
 	resourceOffer data.ResourceOffer
@@ -51,34 +88,83 @@ type moduleIDError struct {
 }
 
 func (_ moduleIDError) matched() bool   { return false }
-func (_ moduleIDError) message() string { return "error getting module ID" }
+func (_ moduleIDError) message() string { return "error computing module ID" }
+func (result moduleIDError) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.String("match_result.err", result.err.Error()),
+		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
+		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
+	}
+}
 
 type moduleMismatch struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer
+	moduleID      string
 }
 
 func (_ moduleMismatch) matched() bool   { return false }
-func (_ moduleMismatch) message() string { return "did not match modules" }
+func (_ moduleMismatch) message() string { return "resource provider does not provide module" }
+func (result moduleMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.String("match_result.module_id", result.moduleID),
+		attribute.StringSlice("match_result.resource_offer.modules", result.resourceOffer.Modules),
+		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
+		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
+	}
+}
 
 type marketPriceUnavailable struct {
 	resourceOffer data.ResourceOffer
-	jobOffer      data.JobOffer
 }
 
 func (_ marketPriceUnavailable) matched() bool { return false }
 func (_ marketPriceUnavailable) message() string {
-	return "do not support market priced resource offers"
+	return "no support for market priced resource offers"
+}
+func (result marketPriceUnavailable) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.String("match_result.resource_offer.mode", string(result.resourceOffer.Mode)),
+	}
 }
 
 type priceMismatch struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer
+	moduleID      string
 }
 
 func (_ priceMismatch) matched() bool { return false }
 func (_ priceMismatch) message() string {
 	return "fixed price job offer cannot afford resource offer"
+}
+func (result priceMismatch) attributes() []attribute.KeyValue {
+	// If the module instruction price is not specified, this lookup will use the zero-value of 0
+	moduleInstructionPrice := result.resourceOffer.ModulePricing[result.moduleID].InstructionPrice
+
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.Int("match_result.job_offer.pricing.instruction_price", int(result.jobOffer.Pricing.InstructionPrice)),
+		attribute.Int("match_result.resource_offer.module_pricing.instruction_price", int(moduleInstructionPrice)),
+		attribute.Int("match_result.resource_offer.default_pricing.instruction_price", int(result.resourceOffer.DefaultPricing.InstructionPrice)),
+		attribute.String("match_result.job_offer.mode", string(result.jobOffer.Mode)),
+		attribute.String("match_result.resource_offer.mode", string(result.resourceOffer.Mode)),
+		attribute.String("match_result.module_id", result.moduleID),
+		attribute.StringSlice("match_result.resource_offer.modules", result.resourceOffer.Modules),
+		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
+		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
+	}
 }
 
 type mediatorMismatch struct {
@@ -88,6 +174,15 @@ type mediatorMismatch struct {
 
 func (_ mediatorMismatch) matched() bool   { return false }
 func (_ mediatorMismatch) message() string { return "no matching mutual mediators" }
+func (result mediatorMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.StringSlice("match_result.job_offer.services.mediator", result.jobOffer.Services.Mediator),
+		attribute.StringSlice("match_result.resource_offer.services.mediator", result.resourceOffer.Services.Mediator),
+	}
+}
 
 type solverMismatch struct {
 	resourceOffer data.ResourceOffer
@@ -96,6 +191,15 @@ type solverMismatch struct {
 
 func (_ solverMismatch) matched() bool   { return false }
 func (_ solverMismatch) message() string { return "no matching solver" }
+func (result solverMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.String("match_result.job_offer.services.solver", result.jobOffer.Services.Solver),
+		attribute.String("match_result.resource_offer.services.solver", result.resourceOffer.Services.Solver),
+	}
+}
 
 // the most basic of matchers
 // basically just check if the resource offer >= job offer cpu, gpu & ram
@@ -147,6 +251,7 @@ func matchOffers(
 			return &moduleMismatch{
 				jobOffer:      jobOffer,
 				resourceOffer: resourceOffer,
+				moduleID:      moduleID,
 			}
 		}
 	}
@@ -154,7 +259,6 @@ func matchOffers(
 	// we don't currently support market priced resource offers
 	if resourceOffer.Mode == data.MarketPrice {
 		return &marketPriceUnavailable{
-			jobOffer:      jobOffer,
 			resourceOffer: resourceOffer,
 		}
 	}
@@ -165,6 +269,7 @@ func matchOffers(
 			return &priceMismatch{
 				jobOffer:      jobOffer,
 				resourceOffer: resourceOffer,
+				moduleID:      moduleID,
 			}
 		}
 	}

--- a/pkg/solver/matcher/matcher.go
+++ b/pkg/solver/matcher/matcher.go
@@ -102,6 +102,7 @@ func GetMatchingDeals(
 			if decision != nil {
 				matchSpan.AddEvent("decision_already_checked",
 					trace.WithAttributes(attribute.Bool("decision.result", decision.Result)))
+				matchSpan.End()
 				continue
 			}
 

--- a/pkg/solver/matcher/matcher.go
+++ b/pkg/solver/matcher/matcher.go
@@ -3,7 +3,6 @@ package matcher
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
@@ -109,11 +108,7 @@ func GetMatchingDeals(
 			matchSpan.AddEvent("match_offers.start")
 			result := matchOffers(resourceOffer.ResourceOffer, jobOffer.JobOffer)
 			logMatch(result)
-			matchSpan.AddEvent("match_offers.done",
-				trace.WithAttributes(attribute.String("result", fmt.Sprintf("%T", result)),
-					attribute.Bool("result.matched", result.matched()),
-					attribute.String("result.message", result.message())),
-			)
+			matchSpan.AddEvent("match_offers.done", trace.WithAttributes(result.attributes()...))
 
 			if result.matched() {
 				matchingResourceOffers = append(matchingResourceOffers, resourceOffer.ResourceOffer)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `solve` trace
  - [x] Add `get_matching_deals` trace
    - [x] Add `get_targeted_deal` trace
    - [x] Add `match` trace
  - [x] Add `add_deal` trace
- [x] Refactor match algorithm to make `moduleID` available one scope out 

This pull request adds a trace to deal making in the solver. It observes matching and reports deals that were made and errors where a deal could not be made.

Preview image:

![CleanShot 2024-10-16 at 15 54 33@2x](https://github.com/user-attachments/assets/eabd26ed-3353-411d-a114-7568fee54ca6)

### Task/Issue reference

Closes: #331 

### Test plan

Tracing over deal making includes a few spans:

- `solve`. The outermost parent span traces over the `solve` function.
- `get_matching_deals`. Child of the `solve` trace.
- `get_targeted_deal`. Child of `get_matching_deals`.
- `match`. Child of `get_matching_deals`.

Query for the `solve` span with:

```
{resource.service.name="solver" && name="solve"}
```

Add `span.deal_ids != "[]"` to filter out spans that did not match any deals:

```
{resource.service.name="solver" && name="solve" && span.deal_ids != "[]"}
```

Adding this filter will helps with testing because `solve` runs every ten seconds, but only one trace will make a match for a test job run.

The `get_matching_deals` span will appear as a child span. It can also be queried directly:

```
{resource.service.name="solver" && name="get_matching_deals" && span.job_offers != "[]"}
```

Filtering with `span.job_offers != "[]"` ignores spans without any matches because they lack a job offer to match on.

A `get_matching_deals` may contain one or more `match` spans. Each `match` span traces a match attempt between a job offer and a resource offer.

When using node targeting, a `get_targeted_deal` span will appear as a child of `get_matching_deals`. This can be queried directly:

```
{resource.service.name="solver" && name="get_targeted_deal"}
```

Use this query to observe targeting attempts that fail when the requested target is not available.

### Details

We use two different methods for tracing a function. When the function does not contain a child span, we wrap the call with `start` and `done` span events. For example:

https://github.com/Lilypad-Tech/lilypad/blob/fbc03828cf247002ad7f62e9c5a34a33cd920634/pkg/solver/matcher/matcher.go#L167-L175

When the function contains a child span, we simply call it passing the context and tracer. For example:

https://github.com/Lilypad-Tech/lilypad/blob/fbc03828cf247002ad7f62e9c5a34a33cd920634/pkg/solver/controller.go#L282

The two approaches give us visibility on each function call, either as a pair of events in a span or a child span.

### Related issues or PRs (optional)

Implements https://github.com/Lilypad-Tech/lilypad/issues/75
