### PR TITLE
fix: exclude canceled job offers

### DIFF
--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -183,6 +183,9 @@ func (solverServer *solverServer) getJobOffers(res corehttp.ResponseWriter, req 
 	if notMatched := req.URL.Query().Get("not_matched"); notMatched == "true" {
 		query.NotMatched = true
 	}
+	if includeCancelled := req.URL.Query().Get("include_cancelled"); includeCancelled == "true" {
+		query.IncludeCancelled = true
+	}
 	return solverServer.store.GetJobOffers(query)
 }
 

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -114,6 +114,9 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 				matching = false
 			}
 		}
+		if !query.IncludeCancelled && jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") {
+			matching = false
+		}
 		if matching {
 			jobOffers = append(jobOffers, *jobOffer)
 		}

--- a/pkg/solver/store/types.go
+++ b/pkg/solver/store/types.go
@@ -9,6 +9,9 @@ type GetJobOffersQuery struct {
 
 	// we use the DealID property of the jobOfferContainer to tell if it's been matched
 	NotMatched bool `json:"not_matched"`
+
+	// this will include cancelled job offers in the results
+	IncludeCancelled bool `json:"include_cancelled"`
 }
 
 type GetResourceOffersQuery struct {


### PR DESCRIPTION
### Summary

This PR adds a `GetJobOffer` query filter to exclude cancelled jobs by default (can be overridden with `query.IncludeCancelled`. 

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/297

### Test plan

- Using main, run a targetted job against a non-existent address. Then run another job (you should see a bunch of "Job cancelled" errors).
- Do the same thing again with this PR - should be resolved.
