### PR TITLE
feat: added public addresses with failover

### DIFF
--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -4,7 +4,7 @@ mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
 api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
-rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://capable-tame-butterfly.arbitrum-sepolia.quiknode.pro/b866a1312df26e5763237e1aff0a300bd4501647"
+rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://arb-sepolia.g.alchemy.com/v2/4PDb7czJf8E6z7ZjhXB0Z5fdU1XaQT0u"
 chain_id = 421614
 controller_address = "0x4a83270045FB4BCd1bdFe1bD6B00762A9D8bbF4E"
 payments_address = "0xdE7CEa09A23e7Aa4980B95F69B8912F39A0e323A"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -4,7 +4,8 @@ mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
 api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
-rpc_url = "wss://capable-tame-butterfly.arbitrum-sepolia.quiknode.pro/b866a1312df26e5763237e1aff0a300bd4501647"
+rpc_url = "wss://arbitrum-sepolia.drpc.org,wss://arbitrum-sepolia-rpc.publicnode.com"
+
 chain_id = 421614
 controller_address = "0x4a83270045FB4BCd1bdFe1bD6B00762A9D8bbF4E"
 payments_address = "0xdE7CEa09A23e7Aa4980B95F69B8912F39A0e323A"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -4,7 +4,7 @@ mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
 api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
-rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://arbitrum-sepolia.drpc.org"
+rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://capable-tame-butterfly.arbitrum-sepolia.quiknode.pro/b866a1312df26e5763237e1aff0a300bd4501647"
 chain_id = 421614
 controller_address = "0x4a83270045FB4BCd1bdFe1bD6B00762A9D8bbF4E"
 payments_address = "0xdE7CEa09A23e7Aa4980B95F69B8912F39A0e323A"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -4,7 +4,7 @@ mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
 api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
-rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://arb-sepolia.g.alchemy.com/v2/4PDb7czJf8E6z7ZjhXB0Z5fdU1XaQT0u"
+rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://rpc.ankr.com/arbitrum_sepolia,wss://arbitrum-sepolia.drpc.org/,wss://testnet-rpc.etherspot.io/v1/421614,wss://endpoints.omniatech.io/v1/arbitrum/sepolia/public,wss://arb-sepolia.g.alchemy.com/v2/4PDb7czJf8E6z7ZjhXB0Z5fdU1XaQT0u"
 chain_id = 421614
 controller_address = "0x4a83270045FB4BCd1bdFe1bD6B00762A9D8bbF4E"
 payments_address = "0xdE7CEa09A23e7Aa4980B95F69B8912F39A0e323A"

--- a/pkg/options/configs/testnet.toml
+++ b/pkg/options/configs/testnet.toml
@@ -4,8 +4,7 @@ mediator = ["0x7B49d6ee530B0A538D26E344f3B02E79ACa96De2"]
 api_host = "https://api-testnet.lilypad.tech/"
 
 [web3]
-rpc_url = "wss://arbitrum-sepolia.drpc.org,wss://arbitrum-sepolia-rpc.publicnode.com"
-
+rpc_url = "wss://arbitrum-sepolia-rpc.publicnode.com,wss://arbitrum-sepolia.drpc.org"
 chain_id = 421614
 controller_address = "0x4a83270045FB4BCd1bdFe1bD6B00762A9D8bbF4E"
 payments_address = "0xdE7CEa09A23e7Aa4980B95F69B8912F39A0e323A"

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -206,6 +206,7 @@ func NewContractSDK(options Web3Options) (*Web3SDK, error) {
 			continue
 		} else {
 			break
+		}
 	}
 
 	privateKey, err := ParsePrivateKey(options.PrivateKey)

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -238,7 +238,6 @@ func NewContractSDK(options Web3Options) (*Web3SDK, error) {
 		TransactOpts: transactOpts,
 		Contracts:    contracts,
 	}
-	// fmt.Printf("Public Address: %s\n", web3SDK.GetAddress())
 	log.Info().Msgf("Public Address: %s", web3SDK.GetAddress())
 
 	return web3SDK, nil

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -196,10 +196,18 @@ func NewContractSDK(options Web3Options) (*Web3SDK, error) {
 	displayOpts.PrivateKey = "*********"
 	log.Debug().Msgf("NewContractSDK: %+v", displayOpts)
 
-	client, err := ethclient.Dial(options.RpcURL)
-	if err != nil {
-		return nil, err
+	rpcs := strings.Split(options.RpcURL, ",")
+	var client *ethclient.Client
+	var err error
+	for _, url := range rpcs {
+		client, err = ethclient.Dial(url)
+		if err != nil {
+			log.Error().Msgf("Failed to connect to %s: %v", url, err)
+			continue
+		} else {
+			break
 	}
+
 	privateKey, err := ParsePrivateKey(options.PrivateKey)
 	if err != nil {
 		return nil, err
@@ -229,7 +237,8 @@ func NewContractSDK(options Web3Options) (*Web3SDK, error) {
 		TransactOpts: transactOpts,
 		Contracts:    contracts,
 	}
-	log.Debug().Msgf("Public Address: %s", web3SDK.GetAddress())
+	// fmt.Printf("Public Address: %s\n", web3SDK.GetAddress())
+	log.Info().Msgf("Public Address: %s", web3SDK.GetAddress())
 
 	return web3SDK, nil
 }


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Added public RPC addresses 
- [x] Failover code to revert to alternate RPC address

We are saturating our RPC endpoint. This fix uses a public rpc with a failover

### Task/Issue reference

Closes: add_link_here

### Test plan
These modifications were tested using my local GPU RP on the lilypad testnet- as a lilypad resource provider

### Details (optional)

Add any additional details that will help to review this pull request.

### Related issues or PRs (optional)

Add any related issues or PRs.
