### PR TITLE
chore: Add web3 sdk tracers

### DIFF
--- a/cmd/lilypad/jobcreator.go
+++ b/cmd/lilypad/jobcreator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func newJobCreatorCmd() *cobra.Command {
@@ -36,7 +37,8 @@ func runJobCreator(cmd *cobra.Command, options jobcreator.JobCreatorOptions) err
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
 
-	web3SDK, err := web3.NewContractSDK(options.Web3)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.JobCreatorService))
+	web3SDK, err := web3.NewContractSDK(commandCtx.Ctx, options.Web3, noopTracer)
 	if err != nil {
 		return err
 	}

--- a/cmd/lilypad/mediator.go
+++ b/cmd/lilypad/mediator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func newMediatorCmd() *cobra.Command {
@@ -38,7 +39,8 @@ func runMediator(cmd *cobra.Command, options mediator.MediatorOptions) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
 
-	web3SDK, err := web3.NewContractSDK(options.Web3)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.MediatorService))
+	web3SDK, err := web3.NewContractSDK(commandCtx.Ctx, options.Web3, noopTracer)
 	if err != nil {
 		return err
 	}

--- a/cmd/lilypad/pow_signal.go
+++ b/cmd/lilypad/pow_signal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func newPowSignalCmd() *cobra.Command {
@@ -42,7 +43,8 @@ func runPowSignal(cmd *cobra.Command, options options.PowSignalOptions) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
 
-	web3SDK, err := web3.NewContractSDK(options.Web3)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.DefaultService))
+	web3SDK, err := web3.NewContractSDK(commandCtx.Ctx, options.Web3, noopTracer)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to initialize Web3 SDK")
 		return err

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -70,7 +70,8 @@ func runResourceProvider(cmd *cobra.Command, options resourceprovider.ResourcePr
 	}
 	commandCtx.Cm.RegisterCallbackWithContext(telemetry.Shutdown)
 
-	resourceProviderService, err := resourceprovider.NewResourceProvider(options, web3SDK, executor, telemetry)
+	tracer := telemetry.TracerProvider.Tracer(system.GetOTelServiceName(system.ResourceProviderService))
+	resourceProviderService, err := resourceprovider.NewResourceProvider(options, web3SDK, executor, tracer)
 	if err != nil {
 		return err
 	}

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func newSolverCmd() *cobra.Command {
@@ -37,7 +38,8 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
 
-	web3SDK, err := web3.NewContractSDK(options.Web3)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.SolverService))
+	web3SDK, err := web3.NewContractSDK(commandCtx.Ctx, options.Web3, noopTracer)
 	if err != nil {
 		return err
 	}

--- a/pkg/jobcreator/run.go
+++ b/pkg/jobcreator/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 type RunJobResults struct {
@@ -19,7 +20,8 @@ func RunJob(
 	options JobCreatorOptions,
 	eventSub JobOfferSubscriber,
 ) (*RunJobResults, error) {
-	web3SDK, err := web3.NewContractSDK(options.Web3)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.JobCreatorService))
+	web3SDK, err := web3.NewContractSDK(ctx.Ctx, options.Web3, noopTracer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -21,14 +21,14 @@ import (
 )
 
 type ResourceProviderController struct {
-	solverClient   *solver.SolverClient
-	options        ResourceProviderOptions
-	web3SDK        *web3.Web3SDK
-	web3Events     *web3.EventChannels
-	loop           *system.ControlLoop
-	log            *system.ServiceLogger
-	tracerProvider trace.TracerProvider
-	executor       executor.Executor
+	solverClient *solver.SolverClient
+	options      ResourceProviderOptions
+	web3SDK      *web3.Web3SDK
+	web3Events   *web3.EventChannels
+	loop         *system.ControlLoop
+	log          *system.ServiceLogger
+	tracer       trace.Tracer
+	executor     executor.Executor
 	// keep track of which jobs are running
 	// this is because no remote state will change
 	// whilst we are actually running a job
@@ -46,7 +46,7 @@ func NewResourceProviderController(
 	options ResourceProviderOptions,
 	web3SDK *web3.Web3SDK,
 	executor executor.Executor,
-	telemetry system.Telemetry,
+	tracer trace.Tracer,
 ) (*ResourceProviderController, error) {
 	// we know the address of the solver but what is it's url?
 	solverUrl, err := web3SDK.GetSolverUrl(options.Offers.Services.Solver)
@@ -66,14 +66,14 @@ func NewResourceProviderController(
 	}
 
 	controller := &ResourceProviderController{
-		solverClient:   solverClient,
-		options:        options,
-		web3SDK:        web3SDK,
-		web3Events:     web3.NewEventChannels(),
-		log:            system.NewServiceLogger(system.ResourceProviderService),
-		tracerProvider: telemetry.TracerProvider,
-		executor:       executor,
-		runningJobs:    map[string]bool{},
+		solverClient: solverClient,
+		options:      options,
+		web3SDK:      web3SDK,
+		web3Events:   web3.NewEventChannels(),
+		log:          system.NewServiceLogger(system.ResourceProviderService),
+		tracer:       tracer,
+		executor:     executor,
+		runningJobs:  map[string]bool{},
 	}
 	return controller, nil
 }
@@ -415,8 +415,7 @@ func (controller *ResourceProviderController) runJob(ctx context.Context, deal d
 	controller.log.Info("deal ID", deal.Deal.ID)
 
 	// Start run job trace
-	service := system.ResourceProviderService
-	ctx, span := controller.tracerProvider.Tracer(system.GetOTelServiceName(service)).Start(ctx, "run_job",
+	ctx, span := controller.tracer.Start(ctx, "run_job",
 		trace.WithAttributes(attribute.String("deal.id", deal.ID)),
 		trace.WithAttributes(attribute.String("deal.job_creator", deal.JobCreator)),
 		trace.WithAttributes(attribute.String("deal.resource_provider", deal.ResourceProvider)),

--- a/pkg/resourceprovider/resourceprovider.go
+++ b/pkg/resourceprovider/resourceprovider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/pow"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // this configures the resource offers we will keep track of
@@ -82,9 +83,9 @@ func NewResourceProvider(
 	options ResourceProviderOptions,
 	web3SDK *web3.Web3SDK,
 	executor executor.Executor,
-	telemetry system.Telemetry,
+	tracer trace.Tracer,
 ) (*ResourceProvider, error) {
-	controller, err := NewResourceProviderController(options, web3SDK, executor, telemetry)
+	controller, err := NewResourceProviderController(options, web3SDK, executor, tracer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/token"
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/users"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // these are the go-binding wrappers for the various deployed contracts
@@ -191,7 +192,7 @@ func NewContracts(
 	}, nil
 }
 
-func NewContractSDK(options Web3Options) (*Web3SDK, error) {
+func NewContractSDK(ctx context.Context, options Web3Options, tracer trace.Tracer) (*Web3SDK, error) {
 	displayOpts := options
 	displayOpts.PrivateKey = "*********"
 	log.Debug().Msgf("NewContractSDK: %+v", displayOpts)

--- a/pkg/web3/sdk_test.go
+++ b/pkg/web3/sdk_test.go
@@ -1,13 +1,17 @@
 package web3_test
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
 	"testing"
+
 	"github.com/BurntSushi/toml"
 	"github.com/lilypad-tech/lilypad/pkg/options"
+	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func getConfig() (*options.Config, error) {
@@ -44,14 +48,14 @@ func CreateTestWeb3SDK() (*web3.Web3SDK, error) {
 		JobCreatorAddress: config.Web3.JobCreatorAddress,
 	}
 
-	sdk, err := web3.NewContractSDK(options)
+	noopTracer := noop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.DefaultService))
+	sdk, err := web3.NewContractSDK(context.Background(), options, noopTracer)
 	if err != nil {
 		return nil, err
 	}
 
 	return sdk, nil
 }
-
 
 func TestGetBalance(t *testing.T) {
 	sdk, err := CreateTestWeb3SDK()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/stretchr/testify/assert"
+	traceNoop "go.opentelemetry.io/otel/trace/noop"
 )
 
 type testOptions struct {
@@ -38,7 +39,8 @@ func getMediator(
 		return nil, err
 	}
 
-	web3SDK, err := web3.NewContractSDK(mediatorOptions.Web3)
+	noopTracer := traceNoop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.MediatorService))
+	web3SDK, err := web3.NewContractSDK(systemContext.Ctx, mediatorOptions.Web3, noopTracer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add tracers to web3 SDK instantiation
- [x] Replace tracerProvider with tracer on resource provider controller
- [x] Add `configureTelemetry` helper function
- [x] Add noop tracers to services that do not trace

This pull request prepares us to add resource provider web3 RPC connection traces (https://github.com/Lilypad-Tech/internal/issues/299). It adds a tracer to `NewContractSDK` which we will use for tracing in an upcoming PR.

### Task/Issue reference

Closes: #376 

### Test plan

Start the observability stack (https://github.com/Lilypad-Tech/observability) with:

```
./stack observe-up dev
```

Run a job and check that a `run_job` trace is recorded.

### Details

#### Noop tracers

Noop tracers were added to all services that call `NewContractSDK` but do not currently trace.

#### tracerProvider -> tracer

This PR takes a new approach to instantiating the `tracer`. We previously instantiated the tracer right before starting the `run_job` trace in the resource provider:

https://github.com/Lilypad-Tech/lilypad/blob/4ddf62dc3a340c771d4c416ad6e1359ddd9908c6/pkg/resourceprovider/controller.go#L419

The OpenTelemetry specification says a [tracer should uniquely identify](https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer) an instrumentation scope. An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is:

> A logical unit of the application code with which the emitted telemetry can be associated. It is typically the developer’s choice to decide what denotes a reasonable instrumentation scope. The most common approach is to use the [instrumentation library](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-library) as the scope, however other scopes are also common, e.g. a module, a package, or a class can be chosen as the instrumentation scope.

After reading this in the spec, I think each of our services can be considered a "logical unit of the application code". 

This pull requests instantiates a single tracer for the resource provider and adds it to the resource provider controller and web3 SDK.
