### PR TITLE
feat: Add get_ethclient trace

### DIFF
--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -204,7 +204,7 @@ func NewContractSDK(ctx context.Context, options Web3Options, tracer trace.Trace
 	for _, url := range rpcs {
 		client, err = ethclient.Dial(url)
 		if err != nil {
-			log.Error().Msgf("Failed to connect to %s: %v", url, err)
+			log.Warn().Msgf("Failed to connect to %s: %v", url, err)
 			continue
 		} else {
 			break

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -198,20 +198,9 @@ func NewContractSDK(ctx context.Context, options Web3Options, tracer trace.Trace
 	displayOpts.PrivateKey = "*********"
 	log.Debug().Msgf("NewContractSDK: %+v", displayOpts)
 
-	rpcs := strings.Split(options.RpcURL, ",")
-	var client *ethclient.Client
-	var err error
-	for _, url := range rpcs {
-		client, err = ethclient.Dial(url)
-		if err != nil {
-			log.Warn().Msgf("Failed to connect to %s: %v", url, err)
-			continue
-		} else {
-			break
-		}
-	}
-	if client == nil {
-		return nil, errors.New("Failed to connect to a web3 RPC provider")
+	client, err := getEthClient(options)
+	if err != nil {
+		return nil, err
 	}
 
 	privateKey, err := ParsePrivateKey(options.PrivateKey)
@@ -246,6 +235,26 @@ func NewContractSDK(ctx context.Context, options Web3Options, tracer trace.Trace
 	log.Info().Msgf("Public Address: %s", web3SDK.GetAddress())
 
 	return web3SDK, nil
+}
+
+func getEthClient(options Web3Options) (*ethclient.Client, error) {
+	rpcs := strings.Split(options.RpcURL, ",")
+	var client *ethclient.Client
+	var err error
+	for _, url := range rpcs {
+		client, err = ethclient.Dial(url)
+		if err != nil {
+			log.Warn().Msgf("Failed to connect to %s: %v", url, err)
+			continue
+		} else {
+			break
+		}
+	}
+	if client == nil {
+		return nil, errors.New("Failed to connect to a web3 RPC provider")
+	}
+
+	return client, nil
 }
 
 func (sdk *Web3SDK) getBlockNumber() (uint64, error) {

--- a/pkg/web3/sdk.go
+++ b/pkg/web3/sdk.go
@@ -3,6 +3,7 @@ package web3
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"math/big"
 	"strconv"
 	"strings"
@@ -208,6 +209,9 @@ func NewContractSDK(ctx context.Context, options Web3Options, tracer trace.Trace
 		} else {
 			break
 		}
+	}
+	if client == nil {
+		return nil, errors.New("Failed to connect to a web3 RPC provider")
 	}
 
 	privateKey, err := ParsePrivateKey(options.PrivateKey)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Refactor `ethclient` dialing into a `getEthClient` function 
- [x] Add a `get_ethclient` trace over `getEthClient`
- [x] Handle error case when all RPC URL connections fail
- [x] Update log level for individual failures to warn

This pull request adds a trace where we connect to web3 RPC URLs when instantiating the web3 SDK.

Note that this trace will only be reported for the solver and resource providers because the other services currently have noop tracers.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/299

### Test plan

Start the observability stack (https://github.com/Lilypad-Tech/observability) with:

```
./stack observe-up dev
```

Start the stack. Open the observability dashboard at `localhost:3000` and run the following TraceQL query:

```
{name="get_ethclient"}
```

Successful connections should be reported for the solver and resource provider.

Update the `WEB3_RPC_URL`:

https://github.com/Lilypad-Tech/lilypad/blob/b97815edf8a89f87e7edaf541d49bbb19206f1cd/.local.dev#L10

to 

```
WEB3_RPC_URL=ws://localhost:-1,ws://localhost:854
```

These changes will exercise two error conditions -- a malformed URL and a URL with an incorrect port. Both should fail and the `get_ethclient` span should be marked with an error because all URLs have failed.

Now update `WEB3_RPC_URL` to:

```
WEB3_RPC_URL=ws://localhost:854,ws://localhost:8548
```

An span event exception should be reported, but the span should be unmarked overall because the second URL should successfully connect.

### Details

Note that the traces only report the host to avoid sending sensitive data like tokens that might be included in the URL.

We may want to randomly select testnet RPC URLs to determine how reliably we can connect to them in the future.
