### PR TITLE
feat: update hostname

### DIFF
--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -37,7 +37,7 @@ const config: HardhatUserConfig = {
       accounts: [getAccount('admin').privateKey],
     },
     devnet: {
-      url: 'http://0.0.0.0:8547',
+      url: 'http://devnet:8547',
       chainId: 412346,
       accounts: [getAccount('admin').privateKey],
     },


### PR DESCRIPTION
### Summary

The hostname is renamed from 0.0.0.0 to devnet in hardhat.config.ts.
This default config simplifies testing of devnet on a LAN.