### PR TITLE
feat: Add Lilypad version HTTP header

### DIFF
--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/rs/zerolog/log"
 )
@@ -23,6 +25,9 @@ const X_LILYPAD_USER_HEADER = "X-Lilypad-User"
 
 // this is the signature of the message
 const X_LILYPAD_SIGNATURE_HEADER = "X-Lilypad-Signature"
+
+// the version run by the client or service
+const X_LILYPAD_VERSION_HEADER = "X-Lilypad-Version"
 
 // the context name we keep the address
 const CONTEXT_ADDRESS = "address"
@@ -100,6 +105,7 @@ func AddHeaders(
 	}
 	req.Header.Add(X_LILYPAD_USER_HEADER, userPayload)
 	req.Header.Add(X_LILYPAD_SIGNATURE_HEADER, userSignature)
+	req.Header.Add(X_LILYPAD_VERSION_HEADER, system.Version)
 	return nil
 }
 
@@ -159,6 +165,14 @@ func GetAddressFromHeaders(req *http.Request) (string, error) {
 	}
 
 	return signatureAddress, nil
+}
+
+func GetVersionFromHeaders(req *http.Request) (string, error) {
+	versionHeader := req.Header.Get(X_LILYPAD_VERSION_HEADER)
+	if versionHeader == "" {
+		return "", errors.New("missing version header")
+	}
+	return versionHeader, nil
 }
 
 func CorsMiddleware(next http.Handler) http.Handler {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -289,6 +289,9 @@ func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res coreht
 }
 
 func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.ResourceOfferContainer, error) {
+	versionHeader, _ := http.GetVersionFromHeaders(req)
+	log.Debug().Msgf("resource provider adding offer with version header %s", versionHeader)
+
 	signerAddress, err := http.GetAddressFromHeaders(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `X-Lilypad-Version` HTTP header
- [x] Log header on solver when receiving resource offers

The `X-Lilypad-Version` header is added to all HTTP requests across services. 

As a demonstration, this PR adds a solver log to report the version when a resource provider makes an add resource offer post. We can remove the log or keep it if it seems useful.

### Task/Issue reference

Closes: #406 

### Test plan

Build the binary with a placeholder version for testing:

```
go build -v -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=v2.9.0' -w" .
```

Run the stack, using the binary for the resource provider and supplying our development-only private key:

```
WEB3_PRIVATE_KEY=0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a ./lilypad resource-provider --network dev
```

Check the solver logs for a "resource provider adding offer with version header v2.9.0" log.
