### PR TITLE
chore: Remove CommandContext.CommandContext

### DIFF
--- a/pkg/system/context.go
+++ b/pkg/system/context.go
@@ -12,10 +12,9 @@ import (
 )
 
 type CommandContext struct {
-	CommandContext context.Context
-	Ctx            context.Context
-	Cm             *CleanupManager
-	CancelFunc     context.CancelFunc
+	Ctx        context.Context
+	Cm         *CleanupManager
+	CancelFunc context.CancelFunc
 }
 
 func NewSystemContext(ctx context.Context) *CommandContext {
@@ -24,10 +23,9 @@ func NewSystemContext(ctx context.Context) *CommandContext {
 	cm := NewCleanupManager()
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
 	return &CommandContext{
-		CommandContext: ctx,
-		Ctx:            ctx,
-		Cm:             cm,
-		CancelFunc:     cancel,
+		Ctx:        ctx,
+		Cm:         cm,
+		CancelFunc: cancel,
 	}
 }
 

--- a/pkg/system/context.go
+++ b/pkg/system/context.go
@@ -62,7 +62,6 @@ func NewCommandContext(cmd *cobra.Command) *CommandContext {
 }
 
 func (cmdContext *CommandContext) Cleanup() {
-	cmdContext.Cm.Cleanup(cmdContext.CommandContext)
 	cmdContext.Cm.Cleanup(cmdContext.Ctx)
 	cmdContext.CancelFunc()
 }


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Remove `CommandContext.CommandContext`

We set up the command context with a `CommandContext.CommandContext` and a `CommandContext.Ctx`, but they are the same context:

https://github.com/Lilypad-Tech/lilypad/blob/b4e56e34a4f6b6b3979e9523731b8952162ad143/pkg/system/context.go#L25-L31

`CommandContext.CommandContext` is not referenced anywhere outside the `CommandContext` type, the set up function, and a clean up call. It seems safe to remove.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/296

### Test plan

Run a job. The job should complete successfully.

When services are shut down after the job, they should no longer emit a `CleanupManager: Cleanup called again after already called` warning.

### Details

We initially noticed this issue when we started seeing `CleanupManager: Cleanup called again after already called` warnings. Cleanup was called on (effectively) the same context, and the same set of functions.

The cleanup manager design isn't entirely clear. We think that functions could be associated with their contexts, and then each cleanup function could be run with its context. The current design does not support this approach.

We may want to revisit in the future if we decide we would like more than one context.
