### PR TITLE
fix: add version info to RP Docker build

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT_SHA=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -102,6 +102,8 @@ services:
       args:
         - NETWORK=dev
         - COMPUTE_MODE=cpu
+        - VERSION=${VERSION}
+        - COMMIT_SHA=${COMMIT_SHA}
     extra_hosts:
       - "localhost:host-gateway"
     volumes:

--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -3,6 +3,8 @@ ARG COMPUTE_MODE=gpu
 FROM nvidia/cuda:12.0.1-cudnn8-devel-ubuntu22.04 AS base
 WORKDIR /usr/src/app
 ARG NETWORK=testnet
+ARG VERSION
+ARG COMMIT_SHA
 
 # Default environment variables
 ENV LOG_LEVEL=info
@@ -28,11 +30,11 @@ COPY . .
 
 FROM base AS build-gpu
 RUN nvcc --version && nvcc --ptx -o ./pkg/resourceprovider/cudaminer/keccak.ptx ./pkg/resourceprovider/cudaminer/keccak.cu
-RUN go build -v --tags cuda
+RUN go build -v -tags cuda -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=${VERSION}' -X 'github.com/lilypad-tech/lilypad/pkg/system.CommitSHA=${COMMIT_SHA}'"
 ENV DISABLE_POW=false
 
 FROM base AS build-cpu
-RUN go build -v
+RUN go build -v -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=${VERSION}' -X 'github.com/lilypad-tech/lilypad/pkg/system.CommitSHA=${COMMIT_SHA}'"
 ENV DISABLE_POW=true
 
 FROM build-$COMPUTE_MODE AS final

--- a/docker/solver/Dockerfile
+++ b/docker/solver/Dockerfile
@@ -8,7 +8,7 @@ ARG network=dev
 
 COPY . .
 RUN go mod download && go mod verify
-RUN go build -v .
+RUN go build -v -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=${VERSION}' -X 'github.com/lilypad-tech/lilypad/pkg/system.CommitSHA=${COMMIT_SHA}'"
 RUN go install
 
 RUN (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sh
@@ -24,9 +24,9 @@ RUN echo "doppler run --command \"cloudflared tunnel run & lilypad solver --netw
 FROM base AS expose-local
 EXPOSE 8080
 RUN if [ "${network}" = "dev" ]; then \
-        echo "lilypad solver --network $network" >> run; \
+    echo "lilypad solver --network $network" >> run; \
     else \
-        echo "doppler run -- lilypad solver --network $network" >> run; \
+    echo "doppler run -- lilypad solver --network $network" >> run; \
     fi
 
 FROM expose-$expose_via AS final

--- a/stack
+++ b/stack
@@ -26,6 +26,7 @@ function compose-init() {
 function compose-build() {
   load-local-env
   compose-env
+  get-build-version
   docker compose -f ./docker/docker-compose.dev.yml build "$@"
 }
 
@@ -51,6 +52,14 @@ function load-local-env() {
       export $line
     fi
   done < .local.dev
+}
+
+############################################################################
+# Get build version info
+############################################################################
+function get-build-version() {
+  export VERSION=$(git rev-parse --abbrev-ref HEAD)
+  export COMMIT_SHA=$(git rev-parse HEAD)
 }
 
 ############################################################################
@@ -274,11 +283,14 @@ function resource-provider() {
 }
 
 function resource-provider-docker-build() {
+  get-build-version
   docker build \
     -t resource-provider \
     -f ./docker/resource-provider/Dockerfile \
     --build-arg NETWORK=dev \
     --build-arg DISABLE_POW=true \
+    --build-arg VERSION=${VERSION} \
+    --build-arg COMMIT_SHA=${COMMIT_SHA} \
     .
 }
 


### PR DESCRIPTION
### Summary

This changes the resource provider `Dockerfile` to take 2 additional build args: `VERSION` and `COMMIT_SHA` to provide to go build.  It also adds those variables to `./stack` build commands and the `release_docker` github workflow. 

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/internal/issues/327

### Test plan

You can test locally by running `./stack compose-build` (you should see the proper `go build` command run) you can then run the full stack locally w/ observability and you should see version info in traces. 
