### PR TITLE
fix: Handle accept result and download result errors

### DIFF
--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -319,7 +319,11 @@ func (controller *JobCreatorController) checkResults() error {
 			// there is an error with the job
 			// accept anyway
 			// TODO: trigger mediation here
-			controller.acceptResult(dealContainer)
+			err := controller.acceptResult(dealContainer)
+			if err != nil {
+				controller.log.Error("failed to accept results", err)
+				return err
+			}
 		} else {
 			controller.downloadResult(dealContainer)
 		}
@@ -337,7 +341,11 @@ func (controller *JobCreatorController) downloadResult(dealContainer data.DealCo
 	controller.log.Debug("Downloaded results for job", solver.GetDownloadsFilePath(dealContainer.ID))
 
 	// TODO: activate the mediation check here
-	controller.acceptResult(dealContainer)
+	err = controller.acceptResult(dealContainer)
+	if err != nil {
+		controller.log.Error("failed to accept results", err)
+		return err
+	}
 
 	// work out if we should check or accept the results
 	// if controller.options.Mediation.CheckResultsPercentage >= rand.Intn(100) {

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -325,7 +325,11 @@ func (controller *JobCreatorController) checkResults() error {
 				return err
 			}
 		} else {
-			controller.downloadResult(dealContainer)
+			err := controller.downloadResult(dealContainer)
+			if err != nil {
+				controller.log.Error("failed to download results", err)
+				return err
+			}
 		}
 	}
 

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -164,7 +164,7 @@ func (controller *JobCreatorController) subscribeToWeb3() error {
 }
 
 func (controller *JobCreatorController) Start(ctx context.Context, cm *system.CleanupManager) chan error {
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	err := controller.subscribeToSolver()
 	if err != nil {
 		errorChan <- err


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Handle `acceptResult` errors
- [x] Handle `downloadResult` errors
- [x] Check for existing downloads before downloading results
- [x] Update error channel to non-blocking buffered channel 

We would like to handle these errors to avoid silently failing when running jobs from the CLI. Error reporting also supports observing this information in traces.

The unbuffered error channel blocks on the receiver which does not get set up before the send. The buffered channel will hold the message until the receiver is available to receive the message.

### Task/Issue reference

Closes: #414 

### Test plan

Run a few jobs. Check that everything still works.

Running more than one job exercises the download check. If we attempt to download again, we would observe a `file exists` error.

To test the error cases, return a temporary error from the `downloadResult` and `acceptResult` functions.

### Details (optional)

The new downloads check determines if we have already downloaded the results for a job. If the download path already exists, we skip the download. This check is necessary because our control loop checks for any completed deals and re-downloads the results. The solver may report completed deals for jobs whose results we already have.
