### PR TITLE
chore: Update CI environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,10 @@ jobs:
         run: ./stack compose-init
 
       - name: Run stack
-        env:
-          DISABLE_TELEMETRY: true
-        run: ./stack compose-up -d
+        run: ./stack compose-up-ci -d
 
       - name: Run tests
-        env:
-          LOG_LEVEL: debug
-          DISABLE_TELEMETRY: true
-        run: ./stack integration-tests
+        run: ./stack integration-tests-ci
 
       - name: Display resource provider logs
         run: docker logs resource-provider

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Build Docker Images
-        run: ./stack compose-build
+        run: ./stack compose-build-ci
 
       - name: Initialize chain
         run: ./stack compose-init

--- a/stack
+++ b/stack
@@ -35,11 +35,21 @@ function compose-up() {
   docker compose -f ./docker/docker-compose.dev.yml up "$@"
 }
 
+function compose-build-ci() {
+  load-local-env
+  compose-env
+  get-build-version
+  export LOG_LEVEL=debug
+  export API_HOST=""
+  export DISABLE_TELEMETRY=true
+  docker compose -f ./docker/docker-compose.dev.yml build "$@"
+}
+
 function compose-up-ci() {
   load-local-env
   compose-env
   export LOG_LEVEL=debug
-  export API_HOST=
+  export API_HOST=""
   export DISABLE_TELEMETRY=true
   docker compose -f ./docker/docker-compose.dev.yml up "$@"
 }
@@ -369,7 +379,7 @@ function integration-tests() {
 function integration-tests-ci() {
   load-local-env
   export LOG_LEVEL=debug
-  export API_HOST=
+  export API_HOST=""
   export DISABLE_TELEMETRY=true
   cd test
   go test -v -count 1 .

--- a/stack
+++ b/stack
@@ -35,11 +35,19 @@ function compose-up() {
   docker compose -f ./docker/docker-compose.dev.yml up "$@"
 }
 
+function compose-up-ci() {
+  load-local-env
+  compose-env
+  export LOG_LEVEL=debug
+  export API_HOST=
+  export DISABLE_TELEMETRY=true
+  docker compose -f ./docker/docker-compose.dev.yml up "$@"
+}
+
 function compose-down() {
   compose-env
   docker compose -f ./docker/docker-compose.dev.yml down
 }
-
 
 ############################################################################
 # Load env variables from .local.dev
@@ -354,6 +362,15 @@ function unit-tests() {
 # see LOCAL_DEVELOPMENT.md
 function integration-tests() {
   load-local-env
+  cd test
+  go test -v -count 1 .
+}
+
+function integration-tests-ci() {
+  load-local-env
+  export LOG_LEVEL=debug
+  export API_HOST=
+  export DISABLE_TELEMETRY=true
   cd test
   go test -v -count 1 .
 }

--- a/stack
+++ b/stack
@@ -10,7 +10,6 @@ OS_ARCH=$(uname -m | awk '{if ($0 ~ /arm64|aarch64/) print "arm64"; else if ($0 
 ############################################################################
 function compose-env() {
   export ADMIN_ADDRESS=${@:-"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}
-  export DISABLE_TELEMETRY=false
 }
 
 function compose-init() {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `compose-up-ci` stack command
- [x] Add `integration-tests-ci` stack command
- [x] Remove unneeded disable telemetry setting

These changes override the environment to avoid calling the API and observability servers in CI.

### Task/Issue reference

Closes: TODO

### Test plan

The CI integration tests should stop reporting calls to the metrics dashboard and telemetry endpoint.
