### PR TITLE
feat: Add custom retryablehttp error handler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Run tests
         env:
           LOG_LEVEL: debug
-          DISABLE_TELEMETRY: true
         run: ./stack integration-tests
 
       - name: Display resource provider logs

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -429,5 +429,15 @@ func newRetryClient() *retryablehttp.Client {
 				Msgf("")
 		}
 	}
+	// Return custom error with response body
+	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		body, err := io.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("%s %s gave up after %d attempt(s): %s", resp.Request.Method, resp.Request.URL, numTries, err)
+		}
+
+		return nil, fmt.Errorf("%s %s gave up after %d attempt(s): %s", resp.Request.Method, resp.Request.URL, numTries, string(body))
+	}
 	return retryClient
 }

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -351,7 +351,7 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 
 	// If the balance is less than the required balance, don't add the resource offer
 	if balance.Cmp(requiredBalanceWei) < 0 {
-		return nil, fmt.Errorf("address %s doesn't have enough funds. required balance is %s but expected balance is %s", resourceOffer.ResourceProvider, requiredBalanceWei, balance)
+		return nil, fmt.Errorf("address %s doesn't have enough ETH balance. The required balance is %s but current balance is %s", resourceOffer.ResourceProvider, requiredBalanceWei, balance)
 	}
 
 	// required LP balance
@@ -361,7 +361,7 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 		return nil, fmt.Errorf("failed to retrieve LP balance for resource provider: %v", err)
 	}
 	if balanceLp.Cmp(requiredBalanceLp) < 0 {
-		return nil, fmt.Errorf("address %s doesn't have enough LP balance. required balance is %s but expected balance is %s", resourceOffer.ResourceProvider, requiredBalanceLp, balanceLp)
+		return nil, fmt.Errorf("address %s doesn't have enough LP balance. The required balance is %s but current balance is %s", resourceOffer.ResourceProvider, requiredBalanceLp, balanceLp)
 	}
 
 	controller.log.Info("add resource offer", resourceOffer)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -73,7 +73,7 @@ func getJobCreatorOptions(options testOptions) (jobcreator.JobCreatorOptions, er
 		return ret, err
 	}
 
-	jobCreatorOptions.Mediation.CheckResultsPercentage = options.moderationChance
+	ret.Mediation.CheckResultsPercentage = options.moderationChance
 	ret.Telemetry.Disable = true
 	ret.Offer.Services.APIHost = ""
 	return ret, nil

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -31,6 +31,7 @@ func getMediator(
 ) (*mediator.Mediator, error) {
 	mediatorOptions := optionsfactory.NewMediatorOptions()
 	mediatorOptions.Web3.PrivateKey = os.Getenv("MEDIATOR_PRIVATE_KEY")
+
 	if mediatorOptions.Web3.PrivateKey == "" {
 		return nil, fmt.Errorf("MEDIATOR_PRIVATE_KEY is not defined")
 	}
@@ -38,6 +39,7 @@ func getMediator(
 	if err != nil {
 		return nil, err
 	}
+	mediatorOptions.Services.APIHost = ""
 
 	noopTracer := traceNoop.NewTracerProvider().Tracer(system.GetOTelServiceName(system.MediatorService))
 	web3SDK, err := web3.NewContractSDK(systemContext.Ctx, mediatorOptions.Web3, noopTracer)
@@ -58,6 +60,7 @@ func getMediator(
 func getJobCreatorOptions(options testOptions) (jobcreator.JobCreatorOptions, error) {
 	jobCreatorOptions := optionsfactory.NewJobCreatorOptions()
 	jobCreatorOptions.Web3.PrivateKey = os.Getenv("JOB_CREATOR_PRIVATE_KEY")
+
 	if jobCreatorOptions.Web3.PrivateKey == "" {
 		return jobCreatorOptions, fmt.Errorf("JOB_CREATOR_PRIVATE_KEY is not defined")
 	}
@@ -71,6 +74,8 @@ func getJobCreatorOptions(options testOptions) (jobcreator.JobCreatorOptions, er
 	}
 
 	jobCreatorOptions.Mediation.CheckResultsPercentage = options.moderationChance
+	ret.Telemetry.Disable = true
+	ret.Offer.Services.APIHost = ""
 	return ret, nil
 }
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add a custom `retryablehttp` error handler that reports the error response body
- [x] Improve low balance error messages
- [x] Disable telemetry and API host in tests
- [x] Fix incorrect mediation option override

We want to report more error details to clients to help them debug issues and provide us with quality bug reports.

### Task/Issue reference

Closes: #420

### Test plan

Add a temporary error that returns immediately from the first line of the `addResourceOffer` handler:

https://github.com/Lilypad-Tech/lilypad/blob/d30b6d81e7f315b37d8a2bf61210c6ef19a9877e/pkg/solver/controller.go#L337-L338

Start the chain and solver.

Reduce the number of retries to 1 or 2 so this doesn't take forever:

https://github.com/Lilypad-Tech/lilypad/blob/d30b6d81e7f315b37d8a2bf61210c6ef19a9877e/pkg/http/utils.go#L415

Start a resource provider. Once the retries are complete, it should crash with an error like:

```
POST http://localhost:8080/api/v1/resource_offers gave up after 2 attempt(s): <some-error>
```

### Details (optional)

We could reduce `retryClient.RetryMax` to a lower number in this PR if we want to.
