### PR TITLE
refactor: Use cleanup manager to unsubscribe web3 subscriptions

### DIFF
--- a/pkg/web3/events_jobcreator.go
+++ b/pkg/web3/events_jobcreator.go
@@ -49,12 +49,7 @@ func (s *JobCreatorEventChannels) Start(
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if jobAddedSub != nil {
-			jobAddedSub.Unsubscribe()
-		}
-	}()
+	cm.RegisterCallback(unsubscribeSub(jobAddedSub))
 
 	for {
 		select {

--- a/pkg/web3/events_mediation.go
+++ b/pkg/web3/events_mediation.go
@@ -49,12 +49,7 @@ func (m *MediationEventChannels) Start(
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if mediationRequestedSub != nil {
-			mediationRequestedSub.Unsubscribe()
-		}
-	}()
+	cm.RegisterCallback(unsubscribeSub(mediationRequestedSub))
 
 	for {
 		select {

--- a/pkg/web3/events_payments.go
+++ b/pkg/web3/events_payments.go
@@ -49,12 +49,8 @@ func (p *PaymentEventChannels) Start(
 	if err != nil {
 		return err
 	}
+	cm.RegisterCallback(unsubscribeSub(paymentSub))
 
-	defer func() {
-		if paymentSub != nil {
-			paymentSub.Unsubscribe()
-		}
-	}()
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/web3/events_pow.go
+++ b/pkg/web3/events_pow.go
@@ -3,6 +3,7 @@ package web3
 import (
 	"context"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/lilypad-tech/lilypad/pkg/system"
@@ -49,12 +50,7 @@ func (s *PowEventChannels) Start(
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if newPowRoundSub != nil {
-			newPowRoundSub.Unsubscribe()
-		}
-	}()
+	cm.RegisterCallback(unsubscribeSub(newPowRoundSub))
 
 	for {
 		select {

--- a/pkg/web3/events_storage.go
+++ b/pkg/web3/events_storage.go
@@ -49,12 +49,7 @@ func (s *StorageEventChannels) Start(
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if dealStateChangeSub != nil {
-			dealStateChangeSub.Unsubscribe()
-		}
-	}()
+	cm.RegisterCallback(unsubscribeSub(dealStateChangeSub))
 
 	for {
 		select {

--- a/pkg/web3/events_token.go
+++ b/pkg/web3/events_token.go
@@ -52,12 +52,7 @@ func (t *TokenEventChannels) Start(
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if transferSub != nil {
-			transferSub.Unsubscribe()
-		}
-	}()
+	cm.RegisterCallback(unsubscribeSub(transferSub))
 
 	for {
 		select {

--- a/pkg/web3/utils.go
+++ b/pkg/web3/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
 )
 
 func GetPublicKey(privateKey *ecdsa.PrivateKey) ecdsa.PublicKey {
@@ -67,4 +68,11 @@ func ConvertStringToBigInt(st string) big.Int {
 func ConvertStringToInt64(st string) uint64 {
 	bigInt := ConvertStringToBigInt(st)
 	return bigInt.Uint64()
+}
+
+func unsubscribeSub(sub event.Subscription) func() error {
+	return func() error {
+		sub.Unsubscribe()
+		return nil
+	}
 }


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Unsubscribe from web3 events using cleanup manager
- [x] Add `unsubscribeSub` helper

This pull request refactors our web3 subscriptions to unsubscribe using our cleanup manager.

### Test plan

Add a temporary print line to the new `unsubscribeSub` helper function to confirm that it is called when exiting the process.

### Details 

This change unsubscribes as a part of our clean up when we receive a cancellation signal.