### PR TITLE
chore: ignore chain data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bin/
 vendor/
 /data/
 .DS_Store
+/chain-data/*


### PR DESCRIPTION
### Summary
/chain-data/* directory does not need to be committed.
