### PR TITLE
feat: solver exponential backoff

### DIFF
--- a/pkg/http/websocket_client.go
+++ b/pkg/http/websocket_client.go
@@ -20,7 +20,7 @@ const (
 )
 
 // ConnectWebSocket establishes a new WebSocket connection
-func ConnectWebSocket(url string, ctx context.Context) (chan []byte, error) {
+func ConnectWebSocket(ctx context.Context, url string) (chan []byte, error) {
 	connectFactory := func() (*websocket.Conn, error) {
 		currentBackoff := 0.0
 		for attempt := 0; attempt < maxAttempts; attempt++ {

--- a/pkg/http/websocket_client.go
+++ b/pkg/http/websocket_client.go
@@ -2,6 +2,10 @@ package http
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net"
 	"sync"
 	"time"
 
@@ -9,23 +13,50 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	initialDelay = 1.0
+	maxAttempts  = 10
+	exponential  = 1.2
+)
+
 // ConnectWebSocket establishes a new WebSocket connection
-func ConnectWebSocket(
-	url string,
-	ctx context.Context,
-) chan []byte {
-	connectFactory := func() *websocket.Conn {
-		for {
+func ConnectWebSocket(url string, ctx context.Context) (chan []byte, error) {
+	connectFactory := func() (*websocket.Conn, error) {
+		currentBackoff := 0.0
+		for attempt := 0; attempt < maxAttempts; attempt++ { // Add condition here
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("websocket connection canceled: %w", ctx.Err())
+			default:
+			}
+
 			log.Debug().Msgf("WebSocket connection connecting: %s", url)
 			conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 			if err != nil {
-				log.Error().Msgf("WebSocket connection failed: %s\nReconnecting in 2 seconds...", err)
-				time.Sleep(2 * time.Second)
+				var netErr *net.OpError
+				if errors.As(err, &netErr) && netErr.Op == "dial" {
+					log.Info().Msg("Solver service appears to be down")
+					return nil, fmt.Errorf("solver service unavailable: %w", err)
+				}
+
+				log.Error().Msgf("WebSocket connection failed: %s\nReconnecting in %.3f seconds...", err, currentBackoff)
+				timer := time.NewTimer(time.Duration(currentBackoff * float64(time.Second)))
+
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, fmt.Errorf("websocket connection canceled during backoff: %w", ctx.Err())
+				case <-timer.C:
+				}
+
+				currentBackoff += initialDelay * math.Pow(exponential, float64(attempt))
 				continue
 			}
+
 			conn.SetPongHandler(nil)
-			return conn
+			return conn, nil
 		}
+		return nil, fmt.Errorf("maximum connection attempts (%d) reached", maxAttempts) // Add this return
 	}
 
 	pingInterval := time.NewTicker(time.Second * 5)
@@ -34,44 +65,66 @@ func ConnectWebSocket(
 	errCh := make(chan error)
 
 	readMessage := func(conn *websocket.Conn) {
+		defer close(responseCh)
 		for {
-			messageType, p, err := conn.ReadMessage()
-			if err != nil {
-				errCh <- err
+			select {
+			case <-ctx.Done():
+				log.Info().Msg("Exiting readMessage loop due to context cancellation.")
 				return
-			}
-			if messageType == websocket.TextMessage {
-				log.Debug().
-					Str("action", "ws READ").
-					Str("payload", string(p)).
-					Msgf("")
-				responseCh <- p
+			default:
+				messageType, p, err := conn.ReadMessage()
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if messageType == websocket.TextMessage {
+					log.Debug().
+						Str("action", "ws READ").
+						Str("payload", string(p)).
+						Msg("")
+					responseCh <- p
+				}
 			}
 		}
 	}
 
-	conn := connectFactory()
+	conn, err := connectFactory()
+	if err != nil {
+		log.Err(err).Msg("Error in WebSocket connection.")
+		return nil, err
+	}
+
 	go readMessage(conn)
+
 	go func() {
+		defer pingInterval.Stop()
 		for {
 			select {
+			case <-ctx.Done():
+				log.Info().Msg("Ping loop exiting due to context cancellation.")
+				return
 			case <-pingInterval.C:
 				connLk.Lock()
-				log.Trace().Msg("send ping message")
+				log.Trace().Msg("Sending ping message.")
 				if err := conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
-					log.Err(err).Msg("sending ping message")
+					log.Err(err).Msg("Error sending ping message.")
 					connLk.Unlock()
-					continue
+					return
 				}
 				connLk.Unlock()
 			case err := <-errCh:
-				log.Err(err).Msg("websocket error")
+				log.Err(err).Msg("WebSocket error detected.")
 				connLk.Lock()
-				conn = connectFactory()
+				conn, err = connectFactory()
 				connLk.Unlock()
+				if err != nil {
+					log.Err(err).Msg("Failed to reconnect WebSocket.")
+					return
+				}
 				go readMessage(conn)
 			}
 		}
 	}()
-	return responseCh
+
+	return responseCh, nil
 }

--- a/pkg/solver/client.go
+++ b/pkg/solver/client.go
@@ -31,7 +31,11 @@ func NewSolverClient(
 func (client *SolverClient) Start(ctx context.Context, cm *system.CleanupManager) error {
 
 	websocketURL := fmt.Sprintf("%s%s%s%s%s", http.WEBSOCKET_SUB_PATH, "?&Type=", client.options.Type, "&ID=", client.options.PublicAddress)
-	websocketEventChannel := http.ConnectWebSocket(http.WebsocketURL(client.options, websocketURL), ctx)
+	websocketEventChannel, err := http.ConnectWebSocket(ctx, http.WebsocketURL(client.options, websocketURL))
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add exponential backoff mechanism for connection retries
- [x] Improve detection of specific WebSocket closure errors
- [x] Add error propagation to ensure issues during WebSocket setup are logged 
- [x] Add mutexes (sync.Mutex) to synchronize access to the WebSocket connection during reconnection or ping operations
- [x] Change the signature of `ConnectWebSocket` to return an error alongside the response channel
- [x] Move ctx to start of params for `SolverClient`

### Task/Issue reference

Closes: #429 

### Test plan

1. Modify `pkg/http/websocket_server.go` to force an error in `HandleFunc`: 
```
r.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
		return
```
2. Start the stack
3. Observe the `job-creator` terminal for exponential backoff logs
```
ERR pkg/http/websocket_client.go:99 > WebSocket connection failed: websocket: bad handshake
Reconnecting in 2.200 seconds...
2024-11-25T11:11:28-05:00 DBG pkg/http/websocket_client.go:99 > WebSocket connection connecting: ws://localhost:8080/api/v1/ws?&Type=JobCreator&ID=0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
2024-11-25T11:11:28-05:00 ERR pkg/http/websocket_client.go:99 > WebSocket connection failed: websocket: bad handshake
Reconnecting in 3.640 seconds...
```
4. Cancel the solver service context to see the context cancellation handling:
```
2024-11-25T11:11:54-05:00 INF pkg/http/websocket_client.go:99 > Solver service appears to be down
2024-11-25T11:11:54-05:00 ERR pkg/solver/client.go:34 > Error in WebSocket connection. error="solver service unavailable: dial tcp [::1]:8080: connect: connection refused"
Error: solver service unavailable: dial tcp [::1]:8080: connect: connection refused
```