### PR TITLE
feat: demonet network config

### DIFF
--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -46,6 +46,11 @@ const config: HardhatUserConfig = {
       chainId: 421614,
       accounts: [getAccount('admin').privateKey],
     },
+    demonet:{
+      url: 'https://demonet-chain-http.lilypad.tech',
+      chainId: 412347,
+      accounts: [getAccount('admin').privateKey],
+    },
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,

--- a/pkg/options/configs/demonet.toml
+++ b/pkg/options/configs/demonet.toml
@@ -1,0 +1,20 @@
+[services]
+solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
+api_host = "https://demonet-chain-http.lilypad.tech/"
+
+[web3]
+rpc_url = "wss://demonet-chain-ws.lilypad.tech"
+chain_id = 412347
+controller_address = "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f"
+payments_address = "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
+storage_address = "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+users_address = "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+token_address = "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
+mediation_address = "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
+jobcreator_address = "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"
+pow_address = "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1"
+
+[telemetry]
+url = "https://observe.lilypad.tech"
+token = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkIjp0cnVlLCJ1c2VyIjoicmVzb3VyY2UtcHJvdmlkZXIifQ.n36M_ngwC4XPQ_pEkkWAnPiOinnx6-0VO1v_WgCTUEERD7b_p9KHCU6SY5bUdFh5UXRZHAhc1gfyc7rjAnmeDQ"

--- a/pkg/options/configs/demonet.toml
+++ b/pkg/options/configs/demonet.toml
@@ -1,7 +1,7 @@
 [services]
 solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
-api_host = "https://demonet-chain-http.lilypad.tech/"
+api_host = ""
 
 [web3]
 rpc_url = "wss://demonet-chain-ws.lilypad.tech"


### PR DESCRIPTION
## Summary
This pull request makes the following changes:

 - Add a configuration file for the new Lilypad Demonet network

These changes are to allow a user to use the --demonet network via a CLI job to point the Lilypad job to the Demonet network _instead_ of the Testnet network.

## Task/Issue reference
https://github.com/Lilypad-Tech/lilypad/issues/430

## Test plan
- When running the code from source go run . --network demonet github.com/lilypad-tech/lilypad-module-lilysay:0.5.2

- When using the lilypad CLI, use lilypad run --network demonet github.com/lilypad-tech/lilypad-module-lilysay:0.5.2