### PR TITLE
feat: Add VRAM and disk space matching

### DIFF
--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -81,6 +81,33 @@ func (result ramMismatch) attributes() []attribute.KeyValue {
 	}
 }
 
+type vramMismatch struct {
+	resourceOffer data.ResourceOffer
+	jobOffer      data.JobOffer
+}
+
+func (_ vramMismatch) matched() bool   { return false }
+func (_ vramMismatch) message() string { return "did not match VRAM" }
+func (result vramMismatch) attributes() []attribute.KeyValue {
+	var resourceOfferVRAMs []int
+	for _, gpu := range result.resourceOffer.Spec.GPUs {
+		resourceOfferVRAMs = append(resourceOfferVRAMs, gpu.VRAM)
+	}
+
+	var jobOfferVRAMS []int
+	for _, gpu := range result.jobOffer.Spec.GPUs {
+		jobOfferVRAMS = append(jobOfferVRAMS, gpu.VRAM)
+	}
+
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.IntSlice("match_result.resource_offer.spec.gpus.vram", resourceOfferVRAMs),
+		attribute.IntSlice("match_result.job_offer.spec.gpus.vram", jobOfferVRAMS),
+	}
+}
+
 type moduleIDError struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -108,6 +108,23 @@ func (result vramMismatch) attributes() []attribute.KeyValue {
 	}
 }
 
+type diskSpaceMismatch struct {
+	resourceOffer data.ResourceOffer
+	jobOffer      data.JobOffer
+}
+
+func (_ diskSpaceMismatch) matched() bool   { return false }
+func (_ diskSpaceMismatch) message() string { return "did not match disk space" }
+func (result diskSpaceMismatch) attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("match_result", fmt.Sprintf("%T", result)),
+		attribute.Bool("match_result.matched", result.matched()),
+		attribute.String("match_result.message", result.message()),
+		attribute.Int("match_result.job_offer.spec.disk", result.jobOffer.Spec.Disk),
+		attribute.Int("match_result.resource_offer.spec.disk", result.resourceOffer.Spec.Disk),
+	}
+}
+
 type moduleIDError struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -292,6 +292,13 @@ func matchOffers(
 		}
 	}
 
+	if resourceOffer.Spec.Disk < jobOffer.Spec.Disk {
+		return &diskSpaceMismatch{
+			jobOffer:      jobOffer,
+			resourceOffer: resourceOffer,
+		}
+	}
+
 	moduleID, err := data.GetModuleID(jobOffer.Module)
 	if err != nil {
 		return &moduleIDError{

--- a/pkg/solver/matcher/matcher_test.go
+++ b/pkg/solver/matcher/matcher_test.go
@@ -26,6 +26,7 @@ func TestMatchOffers(t *testing.T) {
 					VRAM:   24576, // MB
 				},
 			},
+			Disk: 2924295844659, // Bytes
 		},
 		DefaultPricing: data.DealPricing{
 			InstructionPrice: 10,
@@ -40,6 +41,7 @@ func TestMatchOffers(t *testing.T) {
 			GPU:  1000,
 			RAM:  1024,
 			GPUs: []data.GPUSpec{},
+			Disk: 0, // Bytes
 		},
 		Mode:     data.MarketPrice,
 		Services: services,
@@ -163,6 +165,44 @@ func TestMatchOffers(t *testing.T) {
 			jobOffer: func(offer data.JobOffer) data.JobOffer {
 				offer.Module = sdxlModuleConfig
 				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 49152}}
+				return offer
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "Disk space match when job creator specifies disk space",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.Disk = 2924295844659 // Bytes
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.Disk = 1000000000000
+				return offer
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "Disk space match when job creator does not specify disk space",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.Disk = 2924295844659 // Bytes
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.Disk = 0 // zero-value
+				return offer
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "Disk space requested is more than resource offer disk space",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.Disk = 2924295844659 // Bytes
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Spec.Disk = 4000000000000
 				return offer
 			},
 			shouldMatch: false,

--- a/pkg/solver/matcher/matcher_test.go
+++ b/pkg/solver/matcher/matcher_test.go
@@ -19,6 +19,13 @@ func TestMatchOffers(t *testing.T) {
 			CPU: 1000,
 			GPU: 1000,
 			RAM: 1024,
+			GPUs: []data.GPUSpec{
+				{
+					Name:   "NVIDIA RTX 4090",
+					Vendor: "NVIDIA",
+					VRAM:   24576, // MB
+				},
+			},
 		},
 		DefaultPricing: data.DealPricing{
 			InstructionPrice: 10,
@@ -29,9 +36,10 @@ func TestMatchOffers(t *testing.T) {
 
 	basicJobOffer := data.JobOffer{
 		Spec: data.MachineSpec{
-			CPU: 1000,
-			GPU: 1000,
-			RAM: 1024,
+			CPU:  1000,
+			GPU:  1000,
+			RAM:  1024,
+			GPUs: []data.GPUSpec{},
 		},
 		Mode:     data.MarketPrice,
 		Services: services,
@@ -48,6 +56,13 @@ func TestMatchOffers(t *testing.T) {
 		Name: "lilysay",
 		Repo: "https://github.com/Lilypad-Tech/lilypad-module-lilysay",
 		Hash: "v0.5.2",
+		Path: "/lilypad_module.json.tmpl",
+	}
+
+	sdxlModuleConfig := data.ModuleConfig{
+		Name: "",
+		Repo: "https://github.com/Lilypad-Tech/lilypad-module-sdxl",
+		Hash: "v0.9-lilypad1",
 		Path: "/lilypad_module.json.tmpl",
 	}
 
@@ -96,6 +111,58 @@ func TestMatchOffers(t *testing.T) {
 			},
 			jobOffer: func(offer data.JobOffer) data.JobOffer {
 				offer.Spec.GPU = 2048
+				return offer
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "VRAM match when job creator specifies VRAM",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 24576}}
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 20000}}
+				return offer
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "VRAM match when job creator does not specify VRAM",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 24576}}
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.GPUs = []data.GPUSpec{}
+				return offer
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "VRAM requested is more than resource offer VRAM",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 24576}}
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 40000}}
+				return offer
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "VRAM requested but resource offer has none",
+			resourceOffer: func(offer data.ResourceOffer) data.ResourceOffer {
+				offer.Spec.GPUs = []data.GPUSpec{}
+				return offer
+			},
+			jobOffer: func(offer data.JobOffer) data.JobOffer {
+				offer.Module = sdxlModuleConfig
+				offer.Spec.GPUs = []data.GPUSpec{{VRAM: 49152}}
 				return offer
 			},
 			shouldMatch: false,

--- a/pkg/solver/matcher/matcher_test.go
+++ b/pkg/solver/matcher/matcher_test.go
@@ -319,7 +319,7 @@ func TestMatchOffers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := matchOffers(tc.resourceOffer(basicResourceOffer), tc.jobOffer(basicJobOffer))
 			if result.matched() != tc.shouldMatch {
-				t.Errorf("Expected match to be %v, but got %v", tc.shouldMatch, result)
+				t.Errorf("Expected match to be %v, but got %+v", tc.shouldMatch, result)
 			}
 		})
 	}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add VRAM to matching algorithm
- [x] Add disk space to matching algorithm

We want the Solver matching algorithm to match on minimum VRAM and disk space. This pull request implements these constraints.

### Task/Issue reference

Closes: #470

### Test plan

We have added new test cases for VRAM and disk space to our matcher test suite. Run the tests with:

```
go test ./pkg/solver/matcher --tags="unit" --count 1 -v
```

Start the stack. Run a job. Our usual test procedure ensures this pull request does not break anything, but note that it does not exercise cases where a job creator requests VRAM or disk space.

### Details

Resource providers currently report VRAM and disk space in resource offers.

The job offer includes a machine spec, but we have not implemented CLI options for setting GPUs (with VRAM)  or disk space. As a result, GPUs and disk space use default zero values, empty slice and `0` respectively.

### Related issues or PRs

Epic: https://github.com/Lilypad-Tech/internal/issues/367
