### PR TITLE
feat: Add download files signature check

### DIFF
--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -319,6 +319,8 @@ func GetRequestBuffer(
 	if err != nil {
 		return nil, err
 	}
+	privateKey, err := web3.ParsePrivateKey(options.PrivateKey)
+	AddHeaders(req, privateKey, web3.GetAddress(privateKey).String())
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -109,12 +109,12 @@ func AddHeaders(
 	return nil
 }
 
-// this will use the client headers to ensure that a message was signed
-// by the holder of a private key for a specific address
-// there is a "X-Lilypad-User" header that will contain the address
-// there is a "X-Lilypad-Signature" header that will contain the signature
-// we use the signature to verify that the message was signed by the private key
-func GetAddressFromHeaders(req *http.Request) (string, error) {
+// Use the client headers to ensure that a message was signed
+// by the holder of a private key for a specific address.
+// The "X-Lilypad-User" header contains the address.
+// The "X-Lilypad-Signature" header contains the signature.
+// We use the signature to verify that the message was signed by the private key.
+func CheckSignature(req *http.Request) (string, error) {
 	userHeader := req.Header.Get(X_LILYPAD_USER_HEADER)
 	if userHeader == "" {
 		return "", HTTPError{

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -277,7 +277,7 @@ func (solverServer *solverServer) getResult(res corehttp.ResponseWriter, req *co
 *
 */
 func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.JobOfferContainer, error) {
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -298,7 +298,7 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 	versionHeader, _ := http.GetVersionFromHeaders(req)
 	log.Debug().Msgf("resource provider adding offer with version header %s", versionHeader)
 
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -326,7 +326,7 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 	if deal == nil {
 		return nil, fmt.Errorf("deal not found")
 	}
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -367,7 +367,7 @@ func (solverServer *solverServer) updateTransactionsResourceProvider(payload dat
 		log.Error().Err(err).Msgf("deal not found")
 		return nil, fmt.Errorf("deal not found")
 	}
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -391,7 +391,7 @@ func (solverServer *solverServer) updateTransactionsJobCreator(payload data.Deal
 		log.Error().Err(err).Msgf("deal not found")
 		return nil, fmt.Errorf("deal not found")
 	}
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -415,7 +415,7 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 		log.Error().Err(err).Msgf("deal not found")
 		return nil, fmt.Errorf("deal not found")
 	}
-	signerAddress, err := http.GetAddressFromHeaders(req)
+	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("have error parsing user address")
 		return nil, err
@@ -500,7 +500,7 @@ func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *
 			log.Error().Msgf("deal not found")
 			return err
 		}
-		signerAddress, err := http.GetAddressFromHeaders(req)
+		signerAddress, err := http.CheckSignature(req)
 		if err != nil {
 			log.Error().Err(err).Msgf("have error parsing user address")
 			return err

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -279,10 +279,10 @@ func (solverServer *solverServer) getResult(res corehttp.ResponseWriter, req *co
 func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.JobOfferContainer, error) {
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the job creator can post a job offer
+	// Only the job creator can post their job offer
 	if signerAddress != jobOffer.JobCreator {
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
@@ -300,10 +300,10 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the job creator can post a job offer
+	// Only the resource provider can post their resource offer
 	if signerAddress != resourceOffer.ResourceProvider {
 		return nil, fmt.Errorf("resource provider address does not match signer address")
 	}
@@ -328,10 +328,10 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 	}
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the resource provider can add a result
+	// Only the resource provider in a deal can add a result
 	if signerAddress != deal.ResourceProvider {
 		return nil, fmt.Errorf("resource provider address does not match signer address")
 	}
@@ -369,10 +369,10 @@ func (solverServer *solverServer) updateTransactionsResourceProvider(payload dat
 	}
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the job creator can post a job offer
+	// Only the resource provider in a deal can update its transactions
 	if signerAddress != deal.ResourceProvider {
 		return nil, fmt.Errorf("resource provider address does not match signer address")
 	}
@@ -393,10 +393,10 @@ func (solverServer *solverServer) updateTransactionsJobCreator(payload data.Deal
 	}
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the job creator can post a job offer
+	// Only the job creator in a deal can update its transactions
 	if signerAddress != deal.JobCreator {
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
@@ -417,10 +417,10 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 	}
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("have error parsing user address")
+		log.Error().Err(err).Msgf("error checking signature")
 		return nil, err
 	}
-	// only the job creator can post a job offer
+	// Only the mediator in a deal can update its transactions
 	if signerAddress != deal.Mediator {
 		return nil, fmt.Errorf("job creator address does not match mediator address")
 	}
@@ -502,10 +502,10 @@ func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *
 		}
 		signerAddress, err := http.CheckSignature(req)
 		if err != nil {
-			log.Error().Err(err).Msgf("have error parsing user address")
+			log.Error().Err(err).Msgf("error checking signature")
 			return err
 		}
-		// only the resource provider can add a result
+		// Only the resource provider in a deal can upload job outputs
 		if signerAddress != deal.ResourceProvider {
 			return fmt.Errorf("resource provider address does not match signer address")
 		}

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -470,7 +470,7 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 		}
 		// Only the job creator in a deal can download job outputs
 		if signerAddress != deal.JobCreator {
-			log.Error().Err(err).Msgf("resource provider address does not match signer address")
+			log.Error().Err(err).Msgf("job creator address does not match signer address")
 			return &http.HTTPError{
 				Message:    errors.New("not authorized").Error(),
 				StatusCode: corehttp.StatusUnauthorized,


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add signature check to download files route
- [x] Add headers to GET requests
- [x] Rename `GetAddressFromHeaders` to `CheckSignature`
- [x] Update error messages and comments 

This pull request adds a signature check to the download files route to ensure requests comes from the job creator that requested the job.

### Task/Issue reference

Closes: #473 

### Test plan

Start the stack. Run a job. Run the integration tests. Everything should work as expected.

We have also included a temporary commit to test an incorrect signature:

https://github.com/Lilypad-Tech/lilypad/blob/08a162524b158405b06e462ebc4631c300136cb0/pkg/http/utils.go#L323-L324

Comment line 323 and uncomment 324 to force a mismatch between the reported address and the one derived from the signature. Note that this test mechanism works because we do not check signatures on any other GET route (for now).

Note that error returned to the job creator when the signature fails does not correctly report an error message because we have yet to address: https://github.com/Lilypad-Tech/lilypad/issues/424

We will remove the temporary commit before merging this PR.

### Details

This pull request should be considered a minimal first step towards job output retrieval auth. In the future, we may want to implement decentralized auth to enable other actors to download job outputs.


