### PR TITLE
fix: Remove resource offers in DealNegotiating[0] state on disconnect

### DIFF
--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -404,7 +404,8 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 	return ret, nil
 }
 
-func (controller *SolverController) removeResourceOfferByResourceProvider(ID string) error {
+// Remove resource offers in an unmatched DealNegotiating[0] state
+func (controller *SolverController) removeUnmatchedResourceOffers(ID string) error {
 	controller.log.Info("remove resource offer", ID)
 	resourceOffers, err := controller.store.GetResourceOffers(store.GetResourceOffersQuery{
 		ResourceProvider: ID,

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -405,10 +405,10 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 }
 
 // Remove resource offers in an unmatched DealNegotiating[0] state
-func (controller *SolverController) removeUnmatchedResourceOffers(ID string) error {
-	controller.log.Info("remove resource offer", ID)
+func (controller *SolverController) removeUnmatchedResourceOffers(resourceProviderID string) error {
+	controller.log.Info("remove resource offer", resourceProviderID)
 	resourceOffers, err := controller.store.GetResourceOffers(store.GetResourceOffersQuery{
-		ResourceProvider: ID,
+		ResourceProvider: resourceProviderID,
 	})
 	if err != nil {
 		return err
@@ -419,7 +419,7 @@ func (controller *SolverController) removeUnmatchedResourceOffers(ID string) err
 			err = controller.store.RemoveResourceOffer(offer.ID)
 			if err != nil {
 				controller.log.Error("remove resource offer failed",
-					fmt.Errorf("resource provider: %s, offer ID: %s, error: %s", ID, offer.ID, err))
+					fmt.Errorf("resource provider: %s, offer ID: %s, error: %s", resourceProviderID, offer.ID, err))
 			}
 		}
 	}

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -418,7 +418,8 @@ func (controller *SolverController) removeUnmatchedResourceOffers(ID string) err
 		if offer.State == 0 {
 			err = controller.store.RemoveResourceOffer(offer.ID)
 			if err != nil {
-				controller.log.Error("remove resource offer failed: %s", err)
+				controller.log.Error("remove resource offer failed",
+					fmt.Errorf("resource provider: %s, offer ID: %s, error: %s", ID, offer.ID, err))
 			}
 		}
 	}

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -413,13 +413,13 @@ func (controller *SolverController) removeResourceOfferByResourceProvider(ID str
 		return err
 	}
 
-	if len(resourceOffers) == 0 {
-		return nil
-	}
-
-	err = controller.store.RemoveResourceOffer(resourceOffers[0].ID)
-	if err != nil {
-		return err
+	for _, offer := range resourceOffers {
+		if offer.State == 0 {
+			err = controller.store.RemoveResourceOffer(offer.ID)
+			if err != nil {
+				controller.log.Error("remove resource offer failed: %s", err)
+			}
+		}
 	}
 
 	controller.writeEvent(SolverEvent{

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -169,7 +169,7 @@ func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParam
 			CountryCode: connParams.CountryCode,
 			IP:          connParams.IP,
 		})
-		solverServer.controller.removeResourceOfferByResourceProvider(connParams.ID)
+		solverServer.controller.removeUnmatchedResourceOffers(connParams.ID)
 	}
 }
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Fix remove resource offers on resource provider disconnect
- [x] Rename `removeResourceOfferByResourceProvider` to `removeUnmatchedResourceOffers`

This pull request fixes a bug where we sometimes remove the wrong resource offer on disconnect. See https://github.com/Lilypad-Tech/lilypad/issues/467 for details.

The updated code removes resource offers in a unmatched `DealNegotiating[0]` state to avoid matching them when their resource provider is not connected. This approach has the additional benefit of removing multiple resource offers if the resource provider has offered them.

### Task/Issue reference

Closes: #467

### Test plan

We have included a temporary commit (`994bef2`) to demonstrate resource offer removal. The following steps are recommended for testing:

- Start the stack
- Stop the resource provider and observe the resource offers before and after. All offers should be removed because the one posted offer was in a `DealNegotiating[0]` state.
- Restart the resource provider and run a job
- Wait a moment, and stop the resource provider. The resource provider should have added a new resource offer in a `DealNegotiating[0]` state that gets removed, but the resource offer from running the job (in a `ResultsAccepted[3]`) state should be preserved.

### Related issues or PRs (optional)

Epic: https://github.com/Lilypad-Tech/internal/issues/367