### PR TITLE
chore: Cleanup run command output

### DIFF
--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -142,6 +142,7 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network st
 		return err
 	}
 	spinner.Stop()
+	fmt.Printf("🆔  Data ID: %s\n", result.Result.DataID)
 	fmt.Printf("\n🍂 Lilypad job completed, try 👇\n    open %s\n    cat %s/stdout\n    cat %s/stderr\n",
 		solver.GetDownloadsFilePath(result.JobOffer.DealID),
 		solver.GetDownloadsFilePath(result.JobOffer.DealID),

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -142,11 +142,10 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network st
 		return err
 	}
 	spinner.Stop()
-	fmt.Printf("\n🍂 Lilypad job completed, try 👇\n    open %s\n    cat %s/stdout\n    cat %s/stderr\n    https://ipfs.io/ipfs/%s\n",
+	fmt.Printf("\n🍂 Lilypad job completed, try 👇\n    open %s\n    cat %s/stdout\n    cat %s/stderr\n",
 		solver.GetDownloadsFilePath(result.JobOffer.DealID),
 		solver.GetDownloadsFilePath(result.JobOffer.DealID),
 		solver.GetDownloadsFilePath(result.JobOffer.DealID),
-		result.Result.DataID,
 	)
 	return err
 }


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Remove `ipfs.io` URL from run output
- [x] Add data ID to run output

We will stop storing results in IPFS soon, and the IPFS URL will no longer be valid. It's still useful to view the job outputs CID, so this PR reports that as a Data ID.

### Test plan

Start the stack. Run a job using the CLI. Check the output at the end.

### Details

![CleanShot 2024-12-18 at 11 24 41@2x](https://github.com/user-attachments/assets/4fb1dac8-73e4-4d89-a2db-b5f68b72b5d9)
