### PR TITLE
chore: Improve get solver URL error message

### DIFF
--- a/pkg/web3/api.go
+++ b/pkg/web3/api.go
@@ -90,8 +90,7 @@ func (sdk *Web3SDK) GetSolverUrl(address string) (string, error) {
 		common.HexToAddress(address),
 	)
 	if err != nil {
-		log.Error().Msgf("GetUser error")
-		log.Error().Msgf("error: %s", err)
+		log.Error().Msgf("Failed to discover solver URL: %s", err)
 		return "", err
 	}
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Improve `GetSolverUrl` error message when solver URL not found onchain

When attempting to discover the solver URL, we have been reporting a "GetUser" error, which aligns with the code but is confusing for users. This pull request improves the error message.