### PR TITLE
feat: Add resource provider allowlist

### DIFF
--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -9,9 +9,10 @@ type ServerOptions struct {
 }
 
 type AccessControlOptions struct {
-	ValidationTokenSecret     string
-	ValidationTokenExpiration int
-	ValidationTokenKid        string
+	EnableResourceProviderAllowlist bool
+	ValidationTokenSecret           string
+	ValidationTokenExpiration       int
+	ValidationTokenKid              string
 }
 
 type ValidationToken struct {

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -19,9 +19,11 @@ func GetDefaultServerOptions() http.ServerOptions {
 
 func GetDefaultAccessControlOptions() http.AccessControlOptions {
 	return http.AccessControlOptions{
-		ValidationTokenSecret:     GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
-		ValidationTokenExpiration: GetDefaultServeOptionInt("SERVER_VALIDATION_TOKEN_EXPIRATION", 604800), // one week
-		ValidationTokenKid:        GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_KID", ""),
+		// When false, any resource provider may post a resource offer.
+		EnableResourceProviderAllowlist: GetDefaultServeOptionBool("SERVER_ENABLE_RESOURCE_PROVIDER_ALLOWLIST", false),
+		ValidationTokenSecret:           GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
+		ValidationTokenExpiration:       GetDefaultServeOptionInt("SERVER_VALIDATION_TOKEN_EXPIRATION", 604800), // one week
+		ValidationTokenKid:              GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_KID", ""),
 	}
 }
 
@@ -44,6 +46,11 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.Port, "server-port", serverOptions.Port,
 		`The port to bind the api server to (SERVER_PORT).`,
+	)
+	cmd.PersistentFlags().BoolVar(
+		&serverOptions.AccessControl.EnableResourceProviderAllowlist, "server-enable-resource-provider-allowlist",
+		serverOptions.AccessControl.EnableResourceProviderAllowlist,
+		`Enable resource provider allowlist (SERVER_ENABLE_RESOURCE_PROVIDER_ALLOWLIST).`,
 	)
 	cmd.PersistentFlags().StringVar(
 		&serverOptions.AccessControl.ValidationTokenSecret, "server-validation-token-secret",
@@ -70,9 +77,12 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	)
 }
 
-func CheckServerOptions(options http.ServerOptions) error {
+func CheckServerOptions(options http.ServerOptions, storeType string) error {
 	if options.URL == "" {
 		return fmt.Errorf("SERVER_URL is required")
+	}
+	if options.AccessControl.EnableResourceProviderAllowlist && storeType == "memory" {
+		return fmt.Errorf("Enabling the resource provider allowlist requires the database store. Set STORE_TYPE to \"database\".")
 	}
 	if options.AccessControl.ValidationTokenSecret == "" {
 		return fmt.Errorf("SERVER_VALIDATION_TOKEN_SECRET is required")

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -29,11 +29,11 @@ func AddSolverCliFlags(cmd *cobra.Command, options *solver.SolverOptions) {
 }
 
 func CheckSolverOptions(options solver.SolverOptions) error {
-	err := CheckServerOptions(options.Server)
+	err := CheckStoreOptions(options.Store)
 	if err != nil {
 		return err
 	}
-	err = CheckStoreOptions(options.Store)
+	err = CheckServerOptions(options.Server, options.Store.Type)
 	if err != nil {
 		return err
 	}

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -9,6 +9,7 @@ import (
 	corehttp "net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -312,6 +313,21 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 	if signerAddress != resourceOffer.ResourceProvider {
 		return nil, fmt.Errorf("resource provider address does not match signer address")
 	}
+
+	// Resource provider must be in allowlist when enabled
+	if solverServer.options.AccessControl.EnableResourceProviderAllowlist {
+		allowedProviders, err := solverServer.store.GetAllowedResourceProviders()
+		if err != nil {
+			log.Error().Err(err).Msgf("Unable to load resource provider allowlist: %s", err)
+			return nil, err
+		}
+
+		if !slices.Contains(allowedProviders, resourceOffer.ResourceProvider) {
+			log.Debug().Msgf("resource provider not in allowlist %s", resourceOffer.ResourceProvider)
+			return nil, errors.New("resource provider not in beta program, request beta program access here: https://forms.gle/XaE3rRuXVLxTnZto7")
+		}
+	}
+
 	err = data.CheckResourceOffer(resourceOffer)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error checking resource offer")

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -136,6 +136,19 @@ func (store *SolverStoreDatabase) AddMatchDecision(resourceOffer string, jobOffe
 	return decision, nil
 }
 
+func (store *SolverStoreDatabase) AddAllowedResourceProvider(resourceProvider string) (string, error) {
+	record := AllowedResourceProvider{
+		ResourceProvider: resourceProvider,
+	}
+
+	result := store.db.Create(&record)
+	if result.Error != nil {
+		return "", result.Error
+	}
+
+	return resourceProvider, nil
+}
+
 func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([]data.JobOfferContainer, error) {
 	q := store.db.Where([]JobOffer{})
 
@@ -273,6 +286,20 @@ func (store *SolverStoreDatabase) GetMatchDecisions() ([]data.MatchDecision, err
 	}
 
 	return decisions, nil
+}
+
+func (store *SolverStoreDatabase) GetAllowedResourceProviders() ([]string, error) {
+	var records []AllowedResourceProvider
+	if err := store.db.Find(&records).Error; err != nil {
+		return nil, err
+	}
+
+	providers := make([]string, len(records))
+	for i, record := range records {
+		providers[i] = record.ResourceProvider
+	}
+
+	return providers, nil
 }
 
 func (store *SolverStoreDatabase) GetJobOffer(id string) (*data.JobOfferContainer, error) {
@@ -619,6 +646,14 @@ func (store *SolverStoreDatabase) RemoveMatchDecision(resourceOffer string, jobO
 		return result.Error
 	}
 
+	return nil
+}
+
+func (store *SolverStoreDatabase) RemoveAllowedResourceProvider(resourceProvider string) error {
+	result := store.db.Where("resource_provider = ?", resourceProvider).Delete(&AllowedResourceProvider{})
+	if result.Error != nil {
+		return result.Error
+	}
 	return nil
 }
 

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -43,6 +43,7 @@ func NewSolverStoreDatabase(connStr string, gormLogLevel string) (*SolverStoreDa
 	db.AutoMigrate(&Deal{})
 	db.AutoMigrate(&Result{})
 	db.AutoMigrate(&MatchDecision{})
+	db.AutoMigrate(&AllowedResourceProvider{})
 
 	return &SolverStoreDatabase{db}, nil
 }

--- a/pkg/solver/store/db/models.go
+++ b/pkg/solver/store/db/models.go
@@ -47,3 +47,8 @@ type MatchDecision struct {
 	JobOffer      string `gorm:"primaryKey"`
 	Attributes    datatypes.JSONType[data.MatchDecision]
 }
+
+type AllowedResourceProvider struct {
+	gorm.Model
+	ResourceProvider string `gorm:"index"`
+}

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -67,12 +67,14 @@ type SolverStore interface {
 	AddDeal(deal data.DealContainer) (*data.DealContainer, error)
 	AddResult(result data.Result) (*data.Result, error)
 	AddMatchDecision(resourceOffer string, jobOffer string, deal string, result bool) (*data.MatchDecision, error)
+	AddAllowedResourceProvider(resourceProvider string) (string, error)
 	GetJobOffers(query GetJobOffersQuery) ([]data.JobOfferContainer, error)
 	GetResourceOffers(query GetResourceOffersQuery) ([]data.ResourceOfferContainer, error)
 	GetDeals(query GetDealsQuery) ([]data.DealContainer, error)
 	GetDealsAll() ([]data.DealContainer, error)
 	GetResults() ([]data.Result, error)
 	GetMatchDecisions() ([]data.MatchDecision, error)
+	GetAllowedResourceProviders() ([]string, error)
 	GetJobOffer(id string) (*data.JobOfferContainer, error)
 	GetResourceOffer(id string) (*data.ResourceOfferContainer, error)
 	GetResourceOfferByAddress(address string) (*data.ResourceOfferContainer, error)
@@ -91,6 +93,7 @@ type SolverStore interface {
 	RemoveDeal(id string) error
 	RemoveResult(id string) error
 	RemoveMatchDecision(resourceOffer string, jobOffer string) error
+	RemoveAllowedResourceProvider(resourceProvider string) error
 }
 
 func GetMatchID(resourceOffer string, jobOffer string) string {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add allowed resource provider store methods
- [x] Add memory method implementations
- [x] Add database method implementations
- [x] Add memory and database store tests
- [x] Add `SERVER_ENABLE_RESOURCE_PROVIDER_ALLOWLIST` config to enable/disable allowlist (defaults to `false`)
- [x] Check allowlist on `POST /resource_offers` handler when allowlist enabled

We are adding a resource provider allowlist to gate resource offers during our beta program.

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/lilypad/issues/479

### Test plan

We have added a new set of tests for the memory and database implementations of the new allowed resource provider store methods.

To test the allowlist disabled configuration, start the base services, solver, and resource provider.

```
./stack compose-services
./stack solver
```

The resource provider should be able to post it's resource offer. Stop the solver and resource provider.

To test the allowlist enabled configuration, start the solver with the allowlist enabled:

```
./stack solver --server-enable-resource-provider-allowlist true
```

Start the resource provider:

```
./stack resource-provider
```

They will attempt to post their resource offer with retries and eventually fail with an error message:

```
POST http://localhost:8081/api/v1/resource_offers gave up after 11 attempt(s): resource provider not allowed to post resource offer 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
```

Connect to the database with `psql`:

```
docker exec -it postgres psql -U postgres -d solver-db
```

Once in `psql`, insert your resource provider into the `allowed_resource_providers` table:

```
insert into allowed_resource_providers (resource_provider) values ('0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65');
```

Start the resource provider again and it should be able to post its resource offer.

### Details

#### Configuration

The allowlist is enabled or disabled with a environment variable or CLI option:

```
./stack solver --server-enable-resource-provider-allowlist true
SERVER_ENABLE_RESOURCE_PROVIDER_ALLOWLIST=true ./stack solver 
```

The config name got crazy long, so open to suggestions for something shorter. 😄 

### Related issues or PRs

Epic: https://github.com/Lilypad-Tech/internal/issues/367
