### PR TITLE
refactor: use strings.EqualFold

### DIFF
--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -205,7 +205,7 @@ func (s *SolverStoreMemory) GetResourceOfferByAddress(address string) (*data.Res
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	for _, resourceOffer := range s.resourceOfferMap {
-		if strings.ToLower(resourceOffer.ResourceProvider) == strings.ToLower(address) {
+		if strings.EqualFold(resourceOffer.ResourceProvider, address) {
 			return resourceOffer, nil
 		}
 	}


### PR DESCRIPTION
### Summary


`strings.EqualFold` has no memory overhead and has better performance than `strings.ToLower`.

This is a performance test:

```go
package bench

import (
	"strings"
	"testing"
)

func BenchmarkToLower(b *testing.B) {

	str1 := "Windows"
	str2 := "windows"

	for i := 0; i < b.N; i++ {
		if strings.ToLower(str1) == strings.ToLower(str2) {
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {

	str1 := "Windows"
	str2 := "windows"

	for i := 0; i < b.N; i++ {
		if strings.EqualFold(str1, str2) {
		}
	}
}
```

The result:

```shell
goos: darwin
goarch: arm64
BenchmarkToLower-8      31404808                36.99 ns/op            8 B/op          1 allocs/op
BenchmarkEqualFold-8    194780793                5.989 ns/op           0 B/op          0 allocs/op
PASS
```


### Task/Issue reference

Closes: add_link_here

### Test plan

Please describe how reviewers can test the changes in this pull request. If the test plan is challenging to explain in text alone, a short video demonstration may be included.

### Details (optional)

Add any additional details that will help to review this pull request.

### Related issues or PRs (optional)

Add any related issues or PRs.

