### PR TITLE
fix: remove ipfs from docker compose

### DIFF
--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -69,5 +69,4 @@ services:
 volumes:
   bacalhau-data:
   chain-data:
-  ipfs-data:
   postgres-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider
     restart: unless-stopped
-    depends_on:
-      - ipfs
     build:
       context: ..
       dockerfile: ./docker/resource-provider/Dockerfile
@@ -30,7 +28,6 @@ services:
     environment:
       - WEB3_PRIVATE_KEY
       - WEB3_RPC_URL
-      - IPFS_CONNECT=/dns4/ipfs/tcp/5001
       - BACALHAU_API_HOST=bacalhau
       - BACALHAU_NODE_CLIENTAPI_HOST=bacalhau
       - BACALHAU_NODE_CLIENTAPI_PORT=1234
@@ -41,6 +38,5 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 volumes:
-  ipfs-data:
   bacalhau-data:
   lilypad-data:


### PR DESCRIPTION
### Summary

This removes some additional references to (now unused) ipfs from docker compose files.

Follow up to #441 