### PR TITLE
feat: Add validation token endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/go-chi/httprate v0.14.1
 	github.com/go-git/go-git/v5 v5.10.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -13,6 +13,10 @@ type AccessControlOptions struct {
 	ValidationTokenExpiration int
 }
 
+type ValidationToken struct {
+	JWT string
+}
+
 type RateLimiterOptions struct {
 	RequestLimit int
 	WindowLength int

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -1,10 +1,15 @@
 package http
 
 type ServerOptions struct {
-	URL         string
-	Host        string
-	Port        int
-	RateLimiter RateLimiterOptions
+	URL           string
+	Host          string
+	Port          int
+	AccessControl AccessControlOptions
+	RateLimiter   RateLimiterOptions
+}
+
+type AccessControlOptions struct {
+	ValidationTokenSecret string
 }
 
 type RateLimiterOptions struct {

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -9,7 +9,8 @@ type ServerOptions struct {
 }
 
 type AccessControlOptions struct {
-	ValidationTokenSecret string
+	ValidationTokenSecret     string
+	ValidationTokenExpiration int
 }
 
 type RateLimiterOptions struct {

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -9,10 +9,17 @@ import (
 
 func GetDefaultServerOptions() http.ServerOptions {
 	return http.ServerOptions{
-		URL:         GetDefaultServeOptionString("SERVER_URL", ""),
-		Host:        GetDefaultServeOptionString("SERVER_HOST", "0.0.0.0"),
-		Port:        GetDefaultServeOptionInt("SERVER_PORT", 8080), //nolint:gomnd
-		RateLimiter: GetDefaultRateLimiterOptions(),
+		URL:           GetDefaultServeOptionString("SERVER_URL", ""),
+		Host:          GetDefaultServeOptionString("SERVER_HOST", "0.0.0.0"),
+		Port:          GetDefaultServeOptionInt("SERVER_PORT", 8080), //nolint:gomnd
+		AccessControl: GetDefaultAccessControlOptions(),
+		RateLimiter:   GetDefaultRateLimiterOptions(),
+	}
+}
+
+func GetDefaultAccessControlOptions() http.AccessControlOptions {
+	return http.AccessControlOptions{
+		ValidationTokenSecret: GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
 	}
 }
 
@@ -36,6 +43,11 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 		&serverOptions.Port, "server-port", serverOptions.Port,
 		`The port to bind the api server to (SERVER_PORT).`,
 	)
+	cmd.PersistentFlags().StringVar(
+		&serverOptions.AccessControl.ValidationTokenSecret, "server-validation-token-secret",
+		serverOptions.AccessControl.ValidationTokenSecret,
+		`Secret for generating validation service JWTs (SERVER_VALIDATION_TOKEN_SECRET).`,
+	)
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.RateLimiter.RequestLimit, "server-rate-request-limit", serverOptions.RateLimiter.RequestLimit,
 		`The max requests over the rate window length (SERVER_RATE_REQUEST_LIMIT).`,
@@ -49,6 +61,9 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 func CheckServerOptions(options http.ServerOptions) error {
 	if options.URL == "" {
 		return fmt.Errorf("SERVER_URL is required")
+	}
+	if options.AccessControl.ValidationTokenSecret == "" {
+		return fmt.Errorf("SERVER_VALIDATION_TOKEN_SECRET is required")
 	}
 	return nil
 }

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -19,7 +19,8 @@ func GetDefaultServerOptions() http.ServerOptions {
 
 func GetDefaultAccessControlOptions() http.AccessControlOptions {
 	return http.AccessControlOptions{
-		ValidationTokenSecret: GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
+		ValidationTokenSecret:     GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
+		ValidationTokenExpiration: GetDefaultServeOptionInt("SERVER_VALIDATION_TOKEN_EXPIRATION", 604800), // one week
 	}
 }
 
@@ -47,6 +48,11 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 		&serverOptions.AccessControl.ValidationTokenSecret, "server-validation-token-secret",
 		serverOptions.AccessControl.ValidationTokenSecret,
 		`Secret for generating validation service JWTs (SERVER_VALIDATION_TOKEN_SECRET).`,
+	)
+	cmd.PersistentFlags().IntVar(
+		&serverOptions.AccessControl.ValidationTokenExpiration, "server-validation-token-expiration",
+		serverOptions.AccessControl.ValidationTokenExpiration,
+		`Validation service JWT expiration in seconds (SERVER_VALIDATION_TOKEN_EXPIRATION).`,
 	)
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.RateLimiter.RequestLimit, "server-rate-request-limit", serverOptions.RateLimiter.RequestLimit,

--- a/pkg/solver/client.go
+++ b/pkg/solver/client.go
@@ -159,3 +159,9 @@ func (client *SolverClient) DownloadResultFiles(id string, localPath string) err
 	}
 	return system.ExpandTarBuffer(buf, localPath)
 }
+
+// Validation service
+
+func (client *SolverClient) GetValidationToken() (http.ValidationToken, error) {
+	return http.GetRequest[http.ValidationToken](client.options, fmt.Sprintf("/validation_token"), map[string]string{})
+}

--- a/stack
+++ b/stack
@@ -194,13 +194,14 @@ function run-cowsay-onchain() {
 ############################################################################
 # solver
 #
-# Note: The presence of the WEB3_PRIVATE_KEY here is only necessary for local development. You are advised not to import this key into a wallet nor use it for anything other for testing Lilypad locally
+# Note: The presence of the WEB3_PRIVATE_KEY and SERVER_VALIDATION_TOKEN_SECRET are only necessary for local development. You are advised not to import this key into a wallet nor use it for anything other for testing Lilypad locally
 ############################################################################
 
 function solver() {
   load-local-env
   export WEB3_PRIVATE_KEY=${SOLVER_PRIVATE_KEY}
   export LOG_LEVEL=debug
+  export SERVER_VALIDATION_TOKEN_SECRET=912dd001a6613632c066ca10a19254430db2986a84612882a18f838a6360880e
   go run . solver --network dev "$@"
 }
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add solver validation token secret and expiration options
- [x] Add solver validation token endpoint
- [x] Add client validation token helper

We are adding a validation token endpoint to support our upcoming validation service.

### Task/Issue reference

Closes: #486 

### Test plan

We have included a temporary commit (be58e6116ad209533bb608bae05bb4d72ee8b9f7) to show a client request for a token. This temporary commit will be removed before merging this pull request.

### Details

We have added `SERVER_VALIDATION_TOKEN_SECRET` and `SERVER_VALIDATION_TOKEN_EXPIRATION` solver server options. `SERVER_VALIDATION_TOKEN_SECRET` is required and does not have a default value. `SERVER_VALIDATION_TOKEN_EXPIRATION` defaults to a one week, but can be configured to another value in seconds.

The options can be configured through environment variables or CLI options:

```sh
./stack solver --server-validation-token-expiration 500
SERVER_VALIDATION_TOKEN_EXPIRATION=500 ./stack solver
./stack solver --server-validation-token-secret somesecret
SERVER_VALIDATION_TOKEN_SECRET=somesecret ./stack solver
```

Note that the `SERVER_VALIDATION_TOKEN_SECRET` is overridden by the key we have generated for local development: https://github.com/Lilypad-Tech/lilypad/blob/be58e6116ad209533bb608bae05bb4d72ee8b9f7/stack#L204

Comment this line to test.

### Related issues or PRs

Epic: https://www.notion.so/lilypadnetwork/MVP-Validation-176155da99b5801ebeffc417f6b270c7