### PR TITLE
fix: docker setup for RPs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 # This is a docker-compose file for use by Resource Providers
 services:
   bacalhau:
-    image: ghcr.io/lilypad-tech/bacalhau
+    image: ghcr.io/lilypad-tech/bacalhau:latest
     container_name: bacalhau
     restart: unless-stopped
     privileged: true
@@ -17,6 +17,9 @@ services:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider
     restart: unless-stopped
+    depends_on:
+      bacalhau:
+        condition: service_healthy
     build:
       context: ..
       dockerfile: ./docker/resource-provider/Dockerfile

--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -2,15 +2,8 @@ ARG COMPUTE_MODE=gpu
 
 FROM golang:latest AS base
 WORKDIR /usr/src/app
-ARG NETWORK=testnet
 ARG VERSION
 ARG COMMIT_SHA
-
-# Default environment variables
-ENV LOG_LEVEL=info
-ENV BACALHAU_API_HOST="localhost"
-ENV WEB3_PRIVATE_KEY=""
-ENV DISABLE_TELEMETRY=false
 
 COPY . .
 
@@ -28,8 +21,14 @@ RUN go build -v -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version
 ENV DISABLE_POW=true
 
 FROM build-$COMPUTE_MODE AS final
-RUN mv lilypad /usr/local/bin
+# Default environment variables
+ARG NETWORK=testnet
+ARG DISABLE_TELEMETRY=false
+ENV LOG_LEVEL=info
+ENV BACALHAU_API_HOST="localhost"
+ENV WEB3_PRIVATE_KEY=""
 
+RUN mv lilypad /usr/local/bin
 # Install necessary dependencies
 RUN apt update && apt install -y wget bash curl && apt clean
 


### PR DESCRIPTION
### Summary

A few small fixes for the docker configuration for Resource Providers:

- moves most of the build arg / env values to the proper build stage
- adds a service_healthy check to make sure bacalhau has started before starting the RP