### PR TITLE
feat: Add validation token key ID config

### DIFF
--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -11,6 +11,7 @@ type ServerOptions struct {
 type AccessControlOptions struct {
 	ValidationTokenSecret     string
 	ValidationTokenExpiration int
+	ValidationTokenKid        string
 }
 
 type ValidationToken struct {

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -21,6 +21,7 @@ func GetDefaultAccessControlOptions() http.AccessControlOptions {
 	return http.AccessControlOptions{
 		ValidationTokenSecret:     GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_SECRET", ""),
 		ValidationTokenExpiration: GetDefaultServeOptionInt("SERVER_VALIDATION_TOKEN_EXPIRATION", 604800), // one week
+		ValidationTokenKid:        GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_KID", ""),
 	}
 }
 
@@ -54,6 +55,11 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 		serverOptions.AccessControl.ValidationTokenExpiration,
 		`Validation service JWT expiration in seconds (SERVER_VALIDATION_TOKEN_EXPIRATION).`,
 	)
+	cmd.PersistentFlags().StringVar(
+		&serverOptions.AccessControl.ValidationTokenKid, "server-validation-token-kid",
+		serverOptions.AccessControl.ValidationTokenKid,
+		`Key ID header for validation service JWTs (SERVER_VALIDATION_TOKEN_KID).`,
+	)
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.RateLimiter.RequestLimit, "server-rate-request-limit", serverOptions.RateLimiter.RequestLimit,
 		`The max requests over the rate window length (SERVER_RATE_REQUEST_LIMIT).`,
@@ -70,6 +76,9 @@ func CheckServerOptions(options http.ServerOptions) error {
 	}
 	if options.AccessControl.ValidationTokenSecret == "" {
 		return fmt.Errorf("SERVER_VALIDATION_TOKEN_SECRET is required")
+	}
+	if options.AccessControl.ValidationTokenKid == "" {
+		return fmt.Errorf("SERVER_VALIDATION_TOKEN_KID is required")
 	}
 	return nil
 }

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -647,7 +647,7 @@ func (solverServer *solverServer) getValidationToken(res corehttp.ResponseWriter
 	})
 
 	// Add the key ID to the token header
-	token.Header["kid"] = "key-1"
+	token.Header["kid"] = solverServer.options.AccessControl.ValidationTokenKid
 
 	// Sign the token
 	secret := []byte(solverServer.options.AccessControl.ValidationTokenSecret)

--- a/stack
+++ b/stack
@@ -208,6 +208,7 @@ function solver() {
   export STORE_CONN_STR=postgres://postgres:postgres@localhost:5432/solver-db?sslmode=disable
   export STORE_GORM_LOG_LEVEL=silent
   export SERVER_VALIDATION_TOKEN_SECRET=912dd001a6613632c066ca10a19254430db2986a84612882a18f838a6360880e
+  export SERVER_VALIDATION_TOKEN_KID=key-dev
   go run . solver --network dev "$@"
 }
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `SERVER_VALIDATION_TOKEN_KID` CLI option and environment variable

We would like to make the Key ID JWT header configurable to set a different key ID per each network.

### Task/Issue reference

Amends: https://github.com/Lilypad-Tech/lilypad/issues/486

### Test plan

We have included a temporary commit (1f3f971e95b496bb1cca43760291b196026a59d7) to show a client request for a token. This temporary commit will be removed before merging this pull request.

### Details

We have added a `SERVER_VALIDATION_TOKEN_KID` solver server option. `SERVER_VALIDATION_TOKEN_KID` is required and does not have a default value.

The options can be configured through environment variables or CLI options:

```sh
./stack solver --server-validation-token-kid somekid
SERVER_VALIDATION_TOKEN_KID=somekid ./stack solver
```

Note that the `SERVER_VALIDATION_TOKEN_KID` is overridden by the key ID we have set for local development:

https://github.com/Lilypad-Tech/lilypad/blob/1f3f971e95b496bb1cca43760291b196026a59d7/stack#L211

Comment this line to test.

### Related issues or PRs

Epic: https://www.notion.so/lilypadnetwork/MVP-Validation-176155da99b5801ebeffc417f6b270c7
