### PR TITLE
chore: Disable external dependencies for local dev

### DIFF
--- a/.local.dev
+++ b/.local.dev
@@ -1,12 +1,13 @@
-# Running the Lilypad application locally depends on the `.local.dev` file for secrets injection. 
-# This file contains a series of private keys (with no funds on them) that are ONLY meant to be used 
-# for testing this app locally. You are free to replace these keys with your own if you wish; however, 
-# be warned that the `.local.dev` file is not included in the `.gitignore`. Therefore, you must be 
-# vigilant not to commit this file in your PRs. We are not responsible for lost funds as a result of 
-# posting your private keys in your commits/PRs. Unless you have a very good reason to do so, 
+# Running the Lilypad application locally depends on the `.local.dev` file for secrets injection.
+# This file contains a series of private keys (with no funds on them) that are ONLY meant to be used
+# for testing this app locally. You are free to replace these keys with your own if you wish; however,
+# be warned that the `.local.dev` file is not included in the `.gitignore`. Therefore, you must be
+# vigilant not to commit this file in your PRs. We are not responsible for lost funds as a result of
+# posting your private keys in your commits/PRs. Unless you have a very good reason to do so,
 # leave the `.local.dev` file unchanged.
 
-API_HOST=http://localhost:8002/
+API_HOST=
+DISABLE_TELEMETRY=true
 WEB3_RPC_URL=ws://localhost:8548
 SERVER_PORT=8081
 SERVER_URL=http://localhost:8081
@@ -29,4 +30,3 @@ WEB3_TOKEN_ADDRESS_=0xa513E6E4b8f2a923D98304ec87F64353C4D5C853
 WEB3_USERS_ADDRESS=0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82
 BACALHAU_API_HOST=localhost
 BACALHAU_API_PORT=1234
-

--- a/pkg/options/configs/dev.toml
+++ b/pkg/options/configs/dev.toml
@@ -1,7 +1,7 @@
 [services]
 solver = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 mediator = ["0x90F79bf6EB2c4f870365E785982E1f101E93b906"]
-api_host = "http://localhost:8002/"
+api_host = ""
 
 [web3]
 rpc_url = "ws://localhost:8548"

--- a/stack
+++ b/stack
@@ -10,7 +10,6 @@ OS_ARCH=$(uname -m | awk '{if ($0 ~ /arm64|aarch64/) print "arm64"; else if ($0 
 ############################################################################
 function compose-env() {
   export ADMIN_ADDRESS=${@:-"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}
-  export DISABLE_TELEMETRY=false
   export STORE_TYPE=database
   export STORE_CONN_STR=postgres://postgres:postgres@localhost:5432/solver-db?sslmode=disable
   export STORE_GORM_LOG_LEVEL=silent


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Disable API calls in local development
- [x] Disable telemetry in local development

The API and telemetry should not be required by default for local development, but they can be enabled when integrating with them.

### Test plan

Check that the instructions in https://github.com/Lilypad-Tech/lilypad/blob/main/LOCAL_DEVELOPMENT.md work without running the API or observability servers.

### Details

The API and telemetry can be enabled in local development.

Enable API calls by setting the `--api-host` CLI option. For example:

```
./stack solver --api-host http://localhost:8002/
```

Enable telemetry by setting the `--disable-telemetry` CLI option to `false`. For example:

```sh
./stack resource-provider --disable-telemetry=false
```