### PR TITLE
fix: silence usage text

### DIFF
--- a/cmd/lilypad/mediator.go
+++ b/cmd/lilypad/mediator.go
@@ -20,12 +20,13 @@ func newMediatorCmd() *cobra.Command {
 		Long:    "Start the lilypad mediator service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessMediatorOptions(options, network)
 			if err != nil {
 				return err
 			}
+			cmd.SilenceUsage = true
+
 			return runMediator(cmd, options)
 		},
 	}
@@ -44,7 +45,6 @@ func runMediator(cmd *cobra.Command, options mediator.MediatorOptions) error {
 	if err != nil {
 		return err
 	}
-
 
 	executor, err := bacalhau.NewBacalhauExecutor(options.Bacalhau)
 	if err != nil {

--- a/cmd/lilypad/pow_signal.go
+++ b/cmd/lilypad/pow_signal.go
@@ -30,6 +30,8 @@ func newPowSignalCmd() *cobra.Command {
 				log.Error().Err(err).Msg("Failed to process PowSignal options")
 				return err
 			}
+			cmd.SilenceUsage = true
+
 			return runPowSignal(cmd, options)
 		},
 	}

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -19,12 +19,13 @@ func newResourceProviderCmd() *cobra.Command {
 		Long:    "Start the lilypad resource-provider service.",
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessResourceProviderOptions(options, network)
 			if err != nil {
 				return err
 			}
+			cmd.SilenceUsage = true
+
 			return runResourceProvider(cmd, options, network)
 		},
 	}

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -28,12 +28,13 @@ func newRunCmd() *cobra.Command {
 		Long:    "Run a job on the Lilypad network.",
 		Example: "run cowsay:v0.0.1 -i Message=moo",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			network, _ := cmd.Flags().GetString("network")
 			options, err := optionsfactory.ProcessJobCreatorOptions(options, args, network)
 			if err != nil {
 				return err
 			}
+			cmd.SilenceUsage = true
+
 			return runJob(cmd, options, network)
 		},
 	}
@@ -131,8 +132,6 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network st
 			fmt.Printf("failed to start spinner: %s", err)
 			os.Exit(1)
 		}
-
-	
 
 	})
 	if err != nil {

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -28,6 +28,8 @@ func newSolverCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cmd.SilenceUsage = true
+
 			return runSolver(cmd, options, network)
 		},
 	}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Silence usage text in solver, mediator, pow signal, resource provider, run commands

This PR silences usage text after command line options have been parsed.

### Task/Issue reference

Closes: #413

### Test plan

Run a command with a bad CLI option, usage should show. Add an intentional error after command line option parsing to see that usage is not shown.
