### PR TITLE
feat: Remove on chain deal agreement requirement

### DIFF
--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -387,19 +387,22 @@ func (controller *JobCreatorController) downloadResult(dealContainer data.DealCo
 
 func (controller *JobCreatorController) acceptResult(deal data.DealContainer) error {
 	controller.log.Debug("Accepting results for job", deal.ID)
-	txHash, err := controller.web3SDK.AcceptResult(deal.ID)
-	if err != nil {
-		return fmt.Errorf("error calling accept result tx for deal: %s", err.Error())
-	}
-	controller.log.Debug("accept result tx", txHash)
+	// txHash, err := controller.web3SDK.AcceptResult(deal.ID)
+	// if err != nil {
+	// 	return fmt.Errorf("error calling accept result tx for deal: %s", err.Error())
+	// }
+	// controller.log.Debug("accept result tx", txHash)
+	txHash := "0x"
 
 	// we have agreed to the deal so we need to update the tx in the solver
-	_, err = controller.solverClient.UpdateTransactionsJobCreator(deal.ID, data.DealTransactionsJobCreator{
+	_, err := controller.solverClient.UpdateTransactionsJobCreator(deal.ID, data.DealTransactionsJobCreator{
 		AcceptResult: txHash,
 	})
 	if err != nil {
 		return fmt.Errorf("error adding AcceptResult tx hash for deal: %s", err.Error())
 	}
+
+	
 	return nil
 }
 

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -387,11 +387,7 @@ func (controller *JobCreatorController) downloadResult(dealContainer data.DealCo
 
 func (controller *JobCreatorController) acceptResult(deal data.DealContainer) error {
 	controller.log.Debug("Accepting results for job", deal.ID)
-	// txHash, err := controller.web3SDK.AcceptResult(deal.ID)
-	// if err != nil {
-	// 	return fmt.Errorf("error calling accept result tx for deal: %s", err.Error())
-	// }
-	// controller.log.Debug("accept result tx", txHash)
+	// !TODO MAINNET: get txHash for accepting results on chain or get this flow
 	txHash := "0x"
 
 	// we have agreed to the deal so we need to update the tx in the solver

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -526,12 +526,13 @@ func (controller *ResourceProviderController) runJob(ctx context.Context, deal d
 	span.AddEvent("solver.result.added", trace.WithAttributes(attribute.String("result.id", createdResult.ID)))
 
 	span.AddEvent("chain.result.add")
-	txHash, err := controller.web3SDK.AddResult(
-		deal.Deal.ID,
-		createdResult.ID,
-		createdResult.DataID,
-		result.InstructionCount,
-	)
+	// txHash, err := controller.web3SDK.AddResult(
+	// 	deal.Deal.ID,
+	// 	createdResult.ID,
+	// 	createdResult.DataID,
+	// 	result.InstructionCount,
+	// )
+	txHash := "0x"
 	if err != nil {
 		controller.log.Error("error calling add result tx for job", err)
 		span.SetStatus(codes.Error, "add result to chain failed")

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -526,12 +526,7 @@ func (controller *ResourceProviderController) runJob(ctx context.Context, deal d
 	span.AddEvent("solver.result.added", trace.WithAttributes(attribute.String("result.id", createdResult.ID)))
 
 	span.AddEvent("chain.result.add")
-	// txHash, err := controller.web3SDK.AddResult(
-	// 	deal.Deal.ID,
-	// 	createdResult.ID,
-	// 	createdResult.DataID,
-	// 	result.InstructionCount,
-	// )
+	// !TODO MAINNET: get txHash for submittinng results on chain
 	txHash := "0x"
 	if err != nil {
 		controller.log.Error("error calling add result tx for job", err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -448,8 +448,12 @@ func (controller *SolverController) addDeal(ctx context.Context, deal data.Deal)
 
 	controller.log.Info("add deal", deal)
 
+	//creates deal container and sets state to agreed
+	dealContainer := data.GetDealContainer(deal)
+	dealContainer.State = data.GetAgreementStateIndex("DealAgreed")
+
 	span.AddEvent("store.add_deal.start")
-	ret, err := controller.store.AddDeal(data.GetDealContainer(deal))
+	ret, err := controller.store.AddDeal(dealContainer)
 	if err != nil {
 		span.SetStatus(codes.Error, "add deal to store failed")
 		span.RecordError(err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -596,6 +596,9 @@ func (controller *SolverController) updateDealTransactionsJobCreator(id string, 
 	if err != nil {
 		return nil, err
 	}
+	if payload.AcceptResult != "" {
+		return controller.updateDealState(id, data.GetAgreementStateIndex("ResultsAccepted"))
+	}
 	controller.writeEvent(SolverEvent{
 		EventType: JobCreatorTransactionsUpdated,
 		Deal:      dealContainer,

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -366,7 +366,7 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 		return nil, err
 	}
 
-	err = solverServer.updateJobstates(id, "ResultsSubmitted")
+	err = solverServer.updateJobStates(id, "ResultsSubmitted")
 	if err != nil {
 		return nil, err
 	}
@@ -627,7 +627,7 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 			}
 		}
         
-		solverServer.updateJobstates(jobOffer.DealID, "ResultsAccepted")
+		solverServer.updateJobStates(jobOffer.DealID, "ResultsAccepted")
 
 		return solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res)
 	}()
@@ -734,7 +734,7 @@ func (solverServer *solverServer) getValidationToken(res corehttp.ResponseWriter
 
 
 
-func (solverServer *solverServer) updateJobstates(dealID string, state string) (error) {
+func (solverServer *solverServer) updateJobStates(dealID string, state string) (error) {
 	deal, err := solverServer.store.GetDeal(dealID)
 	if err != nil {
 		return err

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -626,6 +626,8 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 				StatusCode: corehttp.StatusUnauthorized,
 			}
 		}
+        
+		solverServer.updateJobstates(jobOffer.DealID, "ResultsAccepted")
 
 		return solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res)
 	}()

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -346,7 +346,23 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 		return nil, err
 	}
 	results.DealID = id
-	return solverServer.store.AddResult(results)
+    
+	storedResult,err := solverServer.store.AddResult(results)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = solverServer.controller.updateDealState(id, data.GetAgreementStateIndex("ResultsSubmitted"))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = solverServer.controller.updateJobOfferState(deal.JobOffer, deal.ID, data.GetAgreementStateIndex("ResultsSubmitted"))
+	if err != nil {
+		return nil, err
+	}
+
+	return storedResult, nil
 }
 
 /*

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -362,6 +362,11 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 		return nil, err
 	}
 
+	_, err = solverServer.controller.updateResourceOfferState(deal.ResourceOffer, deal.ID, data.GetAgreementStateIndex("ResultsSubmitted"))
+	if err != nil {
+		return nil, err
+	}
+
 	return storedResult, nil
 }
 

--- a/stack
+++ b/stack
@@ -278,7 +278,7 @@ function integration-tests-solver() {
 function run() {
   load-local-env
   export WEB3_PRIVATE_KEY=${RUN_PRIVATE_KEY}
-  export LOG_LEVEL=info
+  export LOG_LEVEL=debug
   go run . run --network dev "$@"
 }
 

--- a/stack
+++ b/stack
@@ -278,7 +278,7 @@ function integration-tests-solver() {
 function run() {
   load-local-env
   export WEB3_PRIVATE_KEY=${RUN_PRIVATE_KEY}
-  export LOG_LEVEL=debug
+  export LOG_LEVEL=info
   go run . run --network dev "$@"
 }
 


### PR DESCRIPTION
Makes the following changes to support the API Flow + in preparation for mainnet smart contracts and job creation flow
1. removes deal agreement requirements from the job creator side (still needs to be removed from the cli and resource provider)
2. set deal state to agreed on match (the states need to be revised and rearchitected to match the new smart contracts and job creation flow)

Supporting changes:

**Solver**
- Adds update JobStates helper function to update states across JobOffers, ResourceOffers, and Deal objects in the database in liu of smart contract updates
- Adds support to parse empty skeleton deal acceptance transactions from the JobCreator CLI

**Lilypad CLI**
- removes smart contract call to accept results

**Resource Provider**
- removes smart contract call to post results. Without this with the new solver changes the resource provider does not update its resource offer until it reaches the mandatory condition in the control loop (every 10 minutes).

 NOTE: all smart contract call removal is in preparation for integration with the new smart contracts for mainnet.