### PR TITLE
feat: Update solver database models to use milli timestamps

### DIFF
--- a/pkg/solver/store/db/models.go
+++ b/pkg/solver/store/db/models.go
@@ -7,7 +7,7 @@ import (
 )
 
 type JobOffer struct {
-	gorm.Model
+	gorm.Model `gorm:"type:timestamp(3) with time zone"`
 	CID        string `gorm:"index"`
 	JobCreator string `gorm:"index"`
 	DealID     string `gorm:"index"`
@@ -16,7 +16,7 @@ type JobOffer struct {
 }
 
 type ResourceOffer struct {
-	gorm.Model
+	gorm.Model       `gorm:"type:timestamp(3) with time zone"`
 	CID              string `gorm:"index"`
 	ResourceProvider string `gorm:"index"`
 	DealID           string `gorm:"index"`
@@ -25,7 +25,7 @@ type ResourceOffer struct {
 }
 
 type Deal struct {
-	gorm.Model
+	gorm.Model       `gorm:"type:timestamp(3) with time zone"`
 	CID              string `gorm:"index"`
 	JobCreator       string `gorm:"index"`
 	ResourceProvider string `gorm:"index"`
@@ -35,14 +35,14 @@ type Deal struct {
 }
 
 type Result struct {
-	gorm.Model
+	gorm.Model `gorm:"type:timestamp(3) with time zone"`
 	DealID     string `gorm:"index"` // We query with deal ID for now
 	CID        string
 	Attributes datatypes.JSONType[data.Result]
 }
 
 type MatchDecision struct {
-	gorm.Model
+	gorm.Model    `gorm:"type:timestamp(3) with time zone"`
 	ResourceOffer string `gorm:"primaryKey"`
 	JobOffer      string `gorm:"primaryKey"`
 	Attributes    datatypes.JSONType[data.MatchDecision]


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Update solver database models to use milli timestamps

This pull request prepares us for timing job runs by updating database timestamps to use millisecond precision. Gorm defaults to timestamps with second precision, but we can set millisecond precision with the struct tags added in this pull request.

The struct tags also use `with time zone` to preserve the default timezone information stored by postgres.


### Task/Issue reference

Implements: #506 

### Details

Gorm automigrate does not update column types, so we will have to manually migrate databases.

All of our solver database usage is in local development, so the simplest path forward is to drop the tables and recreate them with the new models.

We can do this in our code base by temporarily adding code to drop the tables, then rely on automigrate to recreate them. Change this block of code:

https://github.com/Lilypad-Tech/lilypad/blob/a6ddf89d6e5bc2814c393e1c5667a3208ec10eee/pkg/solver/store/db/db.go#L41-L45

To first drop the tables then recreate them with the new timestamps:

```go
db.Migrator().DropTable(&JobOffer{})
db.Migrator().DropTable(&ResourceOffer{})
db.Migrator().DropTable(&Deal{})
db.Migrator().DropTable(&Result{})
db.Migrator().DropTable(&MatchDecision{})
db.AutoMigrate(&JobOffer{})
db.AutoMigrate(&ResourceOffer{})
db.AutoMigrate(&Deal{})
db.AutoMigrate(&Result{})
db.AutoMigrate(&MatchDecision{})
```



