### PR TITLE
feat: Add global job timeout

### DIFF
--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -117,6 +117,9 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network st
 		case "JobOfferCancelled":
 			desc = "Job cancelled..."
 			emoji = "😭"
+		case "JobTimedOut":
+			desc = "Job timed out..."
+			emoji = "⏱️"
 		default:
 			desc = st
 			emoji = "🌟"

--- a/pkg/data/enums.go
+++ b/pkg/data/enums.go
@@ -27,6 +27,7 @@ var AgreementState = []string{
 	"TimeoutJudgeResults",
 	"TimeoutMediateResults",
 	"JobOfferCancelled",
+	"JobTimedOut",
 }
 
 // PaymentReason corresponds to PaymentReason in TypeScript
@@ -84,7 +85,11 @@ func IsActiveAgreementState(itemType uint8) bool {
 }
 
 func IsTerminalAgreementState(itemType uint8) bool {
-	return itemType == GetAgreementStateIndex("JobOfferCancelled") || itemType == GetAgreementStateIndex("ResultsAccepted") || itemType == GetAgreementStateIndex("MediationAccepted") || itemType == GetAgreementStateIndex("MediationRejected")
+	return itemType == GetAgreementStateIndex("JobOfferCancelled") ||
+		itemType == GetAgreementStateIndex("JobTimedOut") ||
+		itemType == GetAgreementStateIndex("ResultsAccepted") ||
+		itemType == GetAgreementStateIndex("MediationAccepted") ||
+		itemType == GetAgreementStateIndex("MediationRejected")
 }
 
 // GetPaymentReason corresponds to getPaymentReason in TypeScript

--- a/pkg/jobcreator/run.go
+++ b/pkg/jobcreator/run.go
@@ -118,6 +118,13 @@ waitloop:
 		return nil, fmt.Errorf("job was cancelled")
 	}
 
+	// Check if our job timed out
+	if finalJobOffer.State == data.GetAgreementStateIndex("JobTimedOut") {
+		span.SetStatus(codes.Error, "job timed out")
+		span.RecordError(err)
+		return nil, fmt.Errorf("job timed out")
+	}
+
 	span.AddEvent("get_result.start")
 	result, err := jobCreatorService.GetResult(finalJobOffer.DealID)
 	if err != nil {

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -10,14 +10,13 @@ import (
 
 func NewSolverOptions() solver.SolverOptions {
 	options := solver.SolverOptions{
-		Server:    GetDefaultServerOptions(),
-		Store:     GetDefaultStoreOptions(),
-		Web3:      GetDefaultWeb3Options(),
-		Services:  GetDefaultServicesOptions(),
-		Telemetry: GetDefaultTelemetryOptions(),
-		Metrics:   GetDefaultMetricsOptions(),
-		// Timeout in seconds with a default of ten minutes
-		JobTimeoutSeconds: GetDefaultServeOptionInt("JOB_TIMEOUT_SECONDS", 600),
+		Server:            GetDefaultServerOptions(),
+		Store:             GetDefaultStoreOptions(),
+		Web3:              GetDefaultWeb3Options(),
+		Services:          GetDefaultServicesOptions(),
+		Telemetry:         GetDefaultTelemetryOptions(),
+		Metrics:           GetDefaultMetricsOptions(),
+		JobTimeoutSeconds: GetDefaultServeOptionInt("JOB_TIMEOUT_SECONDS", 600), // 10 minutes
 	}
 	options.Web3.Service = system.SolverService
 	return options

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -17,7 +17,7 @@ func NewSolverOptions() solver.SolverOptions {
 		Telemetry: GetDefaultTelemetryOptions(),
 		Metrics:   GetDefaultMetricsOptions(),
 		// Timeout in seconds with a default of ten minutes
-		JobOfferTimeout: GetDefaultServeOptionInt("JOB_OFFER_TIMEOUT", 600),
+		JobTimeoutSeconds: GetDefaultServeOptionInt("JOB_TIMEOUT_SECONDS", 600),
 	}
 	options.Web3.Service = system.SolverService
 	return options
@@ -31,8 +31,8 @@ func AddSolverCliFlags(cmd *cobra.Command, options *solver.SolverOptions) {
 	AddTelemetryCliFlags(cmd, &options.Telemetry)
 	AddMetricsCliFlags(cmd, &options.Metrics)
 	cmd.PersistentFlags().IntVar(
-		&options.JobOfferTimeout, "job-offer-timeout", options.JobOfferTimeout,
-		`The global timeout for job offers in seconds (JOB_OFFER_TIMEOUT).`,
+		&options.JobTimeoutSeconds, "job-timeout-seconds", options.JobTimeoutSeconds,
+		`The global timeout for jobs in seconds (JOB_TIMEOUT_SECONDS)`,
 	)
 }
 
@@ -57,8 +57,8 @@ func CheckSolverOptions(options solver.SolverOptions) error {
 	if err != nil {
 		return err
 	}
-	if options.JobOfferTimeout <= 0 {
-		return fmt.Errorf("JOB_OFFER_TIMEOUT must be greater than zero")
+	if options.JobTimeoutSeconds <= 0 {
+		return fmt.Errorf("JOB_TIMEOUT_SECONDS must be greater than zero")
 	}
 	return nil
 }

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"fmt"
+
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/spf13/cobra"
@@ -8,12 +10,13 @@ import (
 
 func NewSolverOptions() solver.SolverOptions {
 	options := solver.SolverOptions{
-		Server:    GetDefaultServerOptions(),
-		Store:     GetDefaultStoreOptions(),
-		Web3:      GetDefaultWeb3Options(),
-		Services:  GetDefaultServicesOptions(),
-		Telemetry: GetDefaultTelemetryOptions(),
-		Metrics:   GetDefaultMetricsOptions(),
+		Server:          GetDefaultServerOptions(),
+		Store:           GetDefaultStoreOptions(),
+		Web3:            GetDefaultWeb3Options(),
+		Services:        GetDefaultServicesOptions(),
+		Telemetry:       GetDefaultTelemetryOptions(),
+		Metrics:         GetDefaultMetricsOptions(),
+		JobOfferTimeout: GetDefaultServeOptionInt("JOB_OFFER_TIMEOUT", 600),
 	}
 	options.Web3.Service = system.SolverService
 	return options
@@ -26,6 +29,10 @@ func AddSolverCliFlags(cmd *cobra.Command, options *solver.SolverOptions) {
 	AddServicesCliFlags(cmd, &options.Services)
 	AddTelemetryCliFlags(cmd, &options.Telemetry)
 	AddMetricsCliFlags(cmd, &options.Metrics)
+	cmd.PersistentFlags().IntVar(
+		&options.JobOfferTimeout, "job-offer-timeout", options.JobOfferTimeout,
+		`The global timeout for job offers in seconds (JOB_OFFER_TIMEOUT).`,
+	)
 }
 
 func CheckSolverOptions(options solver.SolverOptions) error {
@@ -48,6 +55,9 @@ func CheckSolverOptions(options solver.SolverOptions) error {
 	err = CheckMetricsOptions(options.Metrics)
 	if err != nil {
 		return err
+	}
+	if options.JobOfferTimeout <= 0 {
+		return fmt.Errorf("JOB_OFFER_TIMEOUT must be greater than zero")
 	}
 	return nil
 }

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -10,12 +10,13 @@ import (
 
 func NewSolverOptions() solver.SolverOptions {
 	options := solver.SolverOptions{
-		Server:          GetDefaultServerOptions(),
-		Store:           GetDefaultStoreOptions(),
-		Web3:            GetDefaultWeb3Options(),
-		Services:        GetDefaultServicesOptions(),
-		Telemetry:       GetDefaultTelemetryOptions(),
-		Metrics:         GetDefaultMetricsOptions(),
+		Server:    GetDefaultServerOptions(),
+		Store:     GetDefaultStoreOptions(),
+		Web3:      GetDefaultWeb3Options(),
+		Services:  GetDefaultServicesOptions(),
+		Telemetry: GetDefaultTelemetryOptions(),
+		Metrics:   GetDefaultMetricsOptions(),
+		// Timeout in seconds with a default of ten minutes
 		JobOfferTimeout: GetDefaultServeOptionInt("JOB_OFFER_TIMEOUT", 600),
 	}
 	options.Web3.Service = system.SolverService

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -320,7 +320,7 @@ func (controller *SolverController) solve(ctx context.Context) error {
 		span.RecordError(err)
 		return err
 	}
-	jobOffers, err := controller.store.GetJobOffers(store.GetJobOffersQuery{Cancelled: true})
+	jobOffers, err := controller.store.GetJobOffers(store.GetJobOffersQuery{Cancelled: system.BoolPointer(true)})
 	if err != nil {
 		span.SetStatus(codes.Error, "get cancelled job offers failed")
 		span.RecordError(err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -368,7 +368,6 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 					controller.log.Error("update expired job offer state failed", err)
 					span.SetStatus(codes.Error, "update expired job offer state failed")
 					span.RecordError(err)
-					return err
 				}
 			} else {
 				// Cancel expired job offers, resource offers, and deals
@@ -377,7 +376,6 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 					controller.log.Error("update expired deal state failed", err)
 					span.SetStatus(codes.Error, "update expired deal state failed")
 					span.RecordError(err)
-					return err
 				}
 				expiredDeals = append(expiredDeals, jobOffer.DealID)
 			}

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -360,7 +360,7 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 	expiredDeals := []string{}
 	for _, jobOffer := range jobOffers {
 		now := time.Now().UnixMilli()
-		if now-int64(jobOffer.JobOffer.CreatedAt) > int64(controller.options.JobOfferTimeout*1000) {
+		if now-int64(jobOffer.JobOffer.CreatedAt) > int64(controller.options.JobTimeoutSeconds*1000) {
 			if jobOffer.DealID == "" {
 				// Cancel expired job offers
 				_, err := controller.updateJobOfferState(jobOffer.ID, jobOffer.DealID, data.GetAgreementStateIndex("JobTimedOut"))

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -326,7 +326,7 @@ func (controller *SolverController) solve(ctx context.Context) error {
 		span.RecordError(err)
 		return err
 	}
-	err = reportDealMetrics(ctx, controller.meter, storedDeals, jobOffers)
+	err = reportJobMetrics(ctx, controller.meter, storedDeals, jobOffers)
 	if err != nil {
 		span.SetStatus(codes.Error, "report deal metrics failed")
 		span.RecordError(err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -290,7 +290,7 @@ func (controller *SolverController) solve(ctx context.Context) error {
 		return err
 	}
 
-	// find out which deals we can make from matching the offers
+	// Match job offers with resource offers to make deals
 	deals, err := matcher.GetMatchingDeals(ctx, controller.store, controller.updateJobOfferState, controller.log, controller.tracer, controller.meter)
 	if err != nil {
 		span.SetStatus(codes.Error, "get matching deals failed")
@@ -302,7 +302,7 @@ func (controller *SolverController) solve(ctx context.Context) error {
 		Value: attribute.StringSliceValue(data.GetDealIDs(deals)),
 	})
 
-	// loop over each of the deals add add them to the store and emit events
+	// Add deals to the store, update offer states, and notify network
 	span.AddEvent("add_deals.start")
 	for _, deal := range deals {
 		_, err := controller.addDeal(ctx, deal)

--- a/pkg/solver/matcher/matcher.go
+++ b/pkg/solver/matcher/matcher.go
@@ -52,6 +52,7 @@ func GetMatchingDeals(
 	span.AddEvent("db.get_job_offers.start")
 	jobOffers, err := db.GetJobOffers(store.GetJobOffersQuery{
 		NotMatched:       true,
+		Cancelled:        system.BoolPointer(false),
 		OrderOldestFirst: true,
 	})
 	if err != nil {

--- a/pkg/solver/metric.go
+++ b/pkg/solver/metric.go
@@ -155,7 +155,7 @@ func newMetrics(meter metric.Meter) (*metrics, error) {
 	}, nil
 }
 
-func reportDealMetrics(ctx context.Context, meter metric.Meter, deals []data.DealContainer, jobOffers []data.JobOfferContainer) error {
+func reportJobMetrics(ctx context.Context, meter metric.Meter, deals []data.DealContainer, jobOffers []data.JobOfferContainer) error {
 	var jobStats jobStats
 
 	// Compute deal state counts

--- a/pkg/solver/metric.go
+++ b/pkg/solver/metric.go
@@ -23,7 +23,7 @@ type metrics struct {
 	jobOfferCancelled     metric.Int64Gauge
 }
 
-type dealStats struct {
+type jobStats struct {
 	stateCounts stateCounts
 }
 
@@ -46,84 +46,84 @@ func newMetrics(meter metric.Meter) (*metrics, error) {
 	// Deal states
 	dealNegotiating, err := meter.Int64Gauge(
 		"solver.deal.state.deal_negotiating",
-		metric.WithDescription("Number of deals in a DealNegotiating state."),
+		metric.WithDescription("Number of jobs in a DealNegotiating state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	dealAgreed, err := meter.Int64Gauge(
 		"solver.deal.state.deal_agreed",
-		metric.WithDescription("Number of deals in a DealAgreed state."),
+		metric.WithDescription("Number of jobs in a DealAgreed state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	resultsSubmitted, err := meter.Int64Gauge(
 		"solver.deal.state.results_submitted",
-		metric.WithDescription("Number of deals in a ResultsSubmitted state."),
+		metric.WithDescription("Number of jobs in a ResultsSubmitted state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	resultsAccepted, err := meter.Int64Gauge(
 		"solver.deal.state.results_accepted",
-		metric.WithDescription("Number of deals in a ResultsAccepted state."),
+		metric.WithDescription("Number of jobs in a ResultsAccepted state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	resultsRejected, err := meter.Int64Gauge(
 		"solver.deal.state.results_rejected",
-		metric.WithDescription("Number of deals in a ResultsRejected state."),
+		metric.WithDescription("Number of jobs in a ResultsRejected state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	resultsChecked, err := meter.Int64Gauge(
 		"solver.deal.state.results_checked",
-		metric.WithDescription("Number of deals in a ResultsChecked state."),
+		metric.WithDescription("Number of jobs in a ResultsChecked state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	mediationAccepted, err := meter.Int64Gauge(
 		"solver.deal.state.mediation_accepted",
-		metric.WithDescription("Number of deals in a MediationAccepted state."),
+		metric.WithDescription("Number of jobs in a MediationAccepted state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	mediationRejected, err := meter.Int64Gauge(
 		"solver.deal.state.mediation_rejected",
-		metric.WithDescription("Number of deals in a MediationRejected state."),
+		metric.WithDescription("Number of jobs in a MediationRejected state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	timeoutSubmitResults, err := meter.Int64Gauge(
 		"solver.deal.state.timeout_submit_results",
-		metric.WithDescription("Number of deals in a TimeoutSubmitResults state."),
+		metric.WithDescription("Number of jobs in a TimeoutSubmitResults state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	timeoutJudgeResults, err := meter.Int64Gauge(
 		"solver.deal.state.timeout_judge_results",
-		metric.WithDescription("Number of deals in a TimeoutJudgeResults state."),
+		metric.WithDescription("Number of jobs in a TimeoutJudgeResults state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	timeoutMediateResults, err := meter.Int64Gauge(
 		"solver.deal.state.timeout_mediate_results",
-		metric.WithDescription("Number of deals in a TimeoutMediateResults state."),
+		metric.WithDescription("Number of jobs in a TimeoutMediateResults state."),
 	)
 	if err != nil {
 		return nil, err
 	}
 	jobOfferCancelled, err := meter.Int64Gauge(
 		"solver.deal.state.job_offer_cancelled",
-		metric.WithDescription("Number of deals in a JobOfferCancelled state."),
+		metric.WithDescription("Number of jobs in a JobOfferCancelled state."),
 	)
 	if err != nil {
 		return nil, err
@@ -146,35 +146,35 @@ func newMetrics(meter metric.Meter) (*metrics, error) {
 }
 
 func reportDealMetrics(ctx context.Context, meter metric.Meter, deals []data.DealContainer) error {
-	var dealStats dealStats
+	var jobStats jobStats
 
 	// Compute deal state counts
 	for _, deal := range deals {
 		switch data.GetAgreementStateString(deal.State) {
 		case "DealNegotiating":
-			dealStats.stateCounts.dealNegotiating += 1
+			jobStats.stateCounts.dealNegotiating += 1
 		case "DealAgreed":
-			dealStats.stateCounts.dealAgreed += 1
+			jobStats.stateCounts.dealAgreed += 1
 		case "ResultsSubmitted":
-			dealStats.stateCounts.resultsSubmitted += 1
+			jobStats.stateCounts.resultsSubmitted += 1
 		case "ResultsAccepted":
-			dealStats.stateCounts.resultsAccepted += 1
+			jobStats.stateCounts.resultsAccepted += 1
 		case "ResultsRejected":
-			dealStats.stateCounts.resultsRejected += 1
+			jobStats.stateCounts.resultsRejected += 1
 		case "ResultsChecked":
-			dealStats.stateCounts.resultsChecked += 1
+			jobStats.stateCounts.resultsChecked += 1
 		case "MediationAccepted":
-			dealStats.stateCounts.mediationAccepted += 1
+			jobStats.stateCounts.mediationAccepted += 1
 		case "MediationRejected":
-			dealStats.stateCounts.mediationRejected += 1
+			jobStats.stateCounts.mediationRejected += 1
 		case "TimeoutSubmitResults":
-			dealStats.stateCounts.timeoutSubmitResults += 1
+			jobStats.stateCounts.timeoutSubmitResults += 1
 		case "TimeoutJudgeResults":
-			dealStats.stateCounts.timeoutJudgeResults += 1
+			jobStats.stateCounts.timeoutJudgeResults += 1
 		case "TimeoutMediateResults":
-			dealStats.stateCounts.timeoutMediateResults += 1
+			jobStats.stateCounts.timeoutMediateResults += 1
 		case "JobOfferCancelled":
-			dealStats.stateCounts.jobOfferCancelled += 1
+			jobStats.stateCounts.jobOfferCancelled += 1
 		default:
 			log.Warn().Msgf("unknown deal state ID: %d", deal.State)
 		}
@@ -186,18 +186,18 @@ func reportDealMetrics(ctx context.Context, meter metric.Meter, deals []data.Dea
 		log.Warn().Msgf("failed to create solver metrics: %s", err)
 		return err
 	}
-	metrics.dealNegotiating.Record(ctx, dealStats.stateCounts.dealNegotiating)
-	metrics.dealAgreed.Record(ctx, dealStats.stateCounts.dealAgreed)
-	metrics.resultsSubmitted.Record(ctx, dealStats.stateCounts.resultsSubmitted)
-	metrics.resultsAccepted.Record(ctx, dealStats.stateCounts.resultsAccepted)
-	metrics.resultsRejected.Record(ctx, dealStats.stateCounts.resultsRejected)
-	metrics.resultsChecked.Record(ctx, dealStats.stateCounts.resultsChecked)
-	metrics.mediationAccepted.Record(ctx, dealStats.stateCounts.mediationAccepted)
-	metrics.mediationRejected.Record(ctx, dealStats.stateCounts.mediationRejected)
-	metrics.timeoutSubmitResults.Record(ctx, dealStats.stateCounts.timeoutSubmitResults)
-	metrics.timeoutJudgeResults.Record(ctx, dealStats.stateCounts.timeoutJudgeResults)
-	metrics.timeoutMediateResults.Record(ctx, dealStats.stateCounts.timeoutMediateResults)
-	metrics.jobOfferCancelled.Record(ctx, dealStats.stateCounts.jobOfferCancelled)
+	metrics.dealNegotiating.Record(ctx, jobStats.stateCounts.dealNegotiating)
+	metrics.dealAgreed.Record(ctx, jobStats.stateCounts.dealAgreed)
+	metrics.resultsSubmitted.Record(ctx, jobStats.stateCounts.resultsSubmitted)
+	metrics.resultsAccepted.Record(ctx, jobStats.stateCounts.resultsAccepted)
+	metrics.resultsRejected.Record(ctx, jobStats.stateCounts.resultsRejected)
+	metrics.resultsChecked.Record(ctx, jobStats.stateCounts.resultsChecked)
+	metrics.mediationAccepted.Record(ctx, jobStats.stateCounts.mediationAccepted)
+	metrics.mediationRejected.Record(ctx, jobStats.stateCounts.mediationRejected)
+	metrics.timeoutSubmitResults.Record(ctx, jobStats.stateCounts.timeoutSubmitResults)
+	metrics.timeoutJudgeResults.Record(ctx, jobStats.stateCounts.timeoutJudgeResults)
+	metrics.timeoutMediateResults.Record(ctx, jobStats.stateCounts.timeoutMediateResults)
+	metrics.jobOfferCancelled.Record(ctx, jobStats.stateCounts.jobOfferCancelled)
 
 	return nil
 }

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -242,6 +242,9 @@ func (solverServer *solverServer) getJobOffers(res corehttp.ResponseWriter, req 
 	if notMatched := req.URL.Query().Get("not_matched"); notMatched == "true" {
 		query.NotMatched = true
 	}
+	if active := req.URL.Query().Get("active"); active == "true" {
+		query.Active = true
+	}
 	if includeCancelled := req.URL.Query().Get("include_cancelled"); includeCancelled == "true" {
 		query.IncludeCancelled = true
 	}

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -411,6 +411,10 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 	if deal == nil {
 		return nil, fmt.Errorf("deal not found")
 	}
+	if deal.State == data.GetAgreementStateIndex("JobTimedOut") {
+		log.Trace().Msgf("attempted results post for timed out job with deal ID: %s", deal.ID)
+		return nil, fmt.Errorf("job with deal ID %s timed out", deal.ID)
+	}
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("error checking signature")
@@ -594,6 +598,10 @@ func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *
 		if deal == nil {
 			log.Error().Msgf("deal not found")
 			return err
+		}
+		if deal.State == data.GetAgreementStateIndex("JobTimedOut") {
+			log.Trace().Msgf("attempted file upload for timed out job with deal ID: %s", deal.ID)
+			return fmt.Errorf("job with deal ID %s timed out", deal.ID)
 		}
 		signerAddress, err := http.CheckSignature(req)
 		if err != nil {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -245,9 +246,14 @@ func (solverServer *solverServer) getJobOffers(res corehttp.ResponseWriter, req 
 	if active := req.URL.Query().Get("active"); active == "true" {
 		query.Active = true
 	}
-	if includeCancelled := req.URL.Query().Get("include_cancelled"); includeCancelled == "true" {
-		query.IncludeCancelled = true
+	if cancelled := req.URL.Query().Get("cancelled"); cancelled != "" {
+		if val, err := strconv.ParseBool(cancelled); err == nil {
+			query.Cancelled = &val
+		} else {
+			return nil, fmt.Errorf("invalid cancelled filter value: %s", cancelled)
+		}
 	}
+
 	return solverServer.store.GetJobOffers(query)
 }
 

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -426,7 +426,7 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 	}
 	err = data.CheckResult(results)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error checking resource offer")
+		log.Error().Err(err).Msgf("Error checking result for deal ID: %s", results.DealID)
 		return nil, err
 	}
 	results.DealID = id

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -15,12 +15,13 @@ import (
 )
 
 type SolverOptions struct {
-	Server    http.ServerOptions
-	Store     store.StoreOptions
-	Web3      web3.Web3Options
-	Services  data.ServiceConfig
-	Telemetry system.TelemetryOptions
-	Metrics   system.MetricsOptions
+	Server          http.ServerOptions
+	Store           store.StoreOptions
+	Web3            web3.Web3Options
+	Services        data.ServiceConfig
+	Telemetry       system.TelemetryOptions
+	Metrics         system.MetricsOptions
+	JobOfferTimeout int
 }
 
 type Solver struct {

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -15,13 +15,13 @@ import (
 )
 
 type SolverOptions struct {
-	Server          http.ServerOptions
-	Store           store.StoreOptions
-	Web3            web3.Web3Options
-	Services        data.ServiceConfig
-	Telemetry       system.TelemetryOptions
-	Metrics         system.MetricsOptions
-	JobOfferTimeout int
+	Server            http.ServerOptions
+	Store             store.StoreOptions
+	Web3              web3.Web3Options
+	Services          data.ServiceConfig
+	Telemetry         system.TelemetryOptions
+	Metrics           system.MetricsOptions
+	JobTimeoutSeconds int
 }
 
 type Solver struct {

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -166,16 +166,18 @@ func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([
 			data.GetAgreementStateIndex("ResultsSubmitted"),
 		})
 	}
-	if query.Cancelled {
-		q = q.Where("state IN (?)", []uint8{
-			data.GetAgreementStateIndex("JobOfferCancelled"),
-			data.GetAgreementStateIndex("JobTimedOut"),
-		})
-	} else if !query.IncludeCancelled {
-		q = q.Where("state NOT IN (?)", []uint8{
-			data.GetAgreementStateIndex("JobOfferCancelled"),
-			data.GetAgreementStateIndex("JobTimedOut"),
-		})
+	if query.Cancelled != nil {
+		if *query.Cancelled {
+			q = q.Where("state IN (?)", []uint8{
+				data.GetAgreementStateIndex("JobOfferCancelled"),
+				data.GetAgreementStateIndex("JobTimedOut"),
+			})
+		} else {
+			q = q.Where("state NOT IN (?)", []uint8{
+				data.GetAgreementStateIndex("JobOfferCancelled"),
+				data.GetAgreementStateIndex("JobTimedOut"),
+			})
+		}
 	}
 	if query.OrderOldestFirst {
 		q = q.Order("created_at ASC")

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -167,7 +167,10 @@ func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([
 		})
 	}
 	if !query.IncludeCancelled {
-		q = q.Where("state != ?", data.GetAgreementStateIndex("JobOfferCancelled"))
+		q = q.Where("state NOT IN (?)", []uint8{
+			data.GetAgreementStateIndex("JobOfferCancelled"),
+			data.GetAgreementStateIndex("JobTimedOut"),
+		})
 	}
 	if query.OrderOldestFirst {
 		q = q.Order("created_at ASC")

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -159,6 +159,13 @@ func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([
 	if query.NotMatched {
 		q = q.Where("deal_id = ''")
 	}
+	if query.Active {
+		q = q.Where("state IN (?)", []uint8{
+			data.GetAgreementStateIndex("DealNegotiating"),
+			data.GetAgreementStateIndex("DealAgreed"),
+			data.GetAgreementStateIndex("ResultsSubmitted"),
+		})
+	}
 	if !query.IncludeCancelled {
 		q = q.Where("state != ?", data.GetAgreementStateIndex("JobOfferCancelled"))
 	}

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -166,7 +166,12 @@ func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([
 			data.GetAgreementStateIndex("ResultsSubmitted"),
 		})
 	}
-	if !query.IncludeCancelled {
+	if query.Cancelled {
+		q = q.Where("state IN (?)", []uint8{
+			data.GetAgreementStateIndex("JobOfferCancelled"),
+			data.GetAgreementStateIndex("JobTimedOut"),
+		})
+	} else if !query.IncludeCancelled {
 		q = q.Where("state NOT IN (?)", []uint8{
 			data.GetAgreementStateIndex("JobOfferCancelled"),
 			data.GetAgreementStateIndex("JobTimedOut"),

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -115,14 +115,11 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 			isCancelled := jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
 				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut")
 
-			if *query.Cancelled {
-				if !isCancelled {
-					matching = false
-				}
-			} else {
-				if isCancelled {
-					matching = false
-				}
+			wantCancelled := *query.Cancelled
+			if wantCancelled && !isCancelled {
+				matching = false
+			} else if !wantCancelled && isCancelled {
+				matching = false
 			}
 		}
 		if matching {

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -111,10 +111,16 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 			jobOffer.State != data.GetAgreementStateIndex("ResultsSubmitted") {
 			matching = false
 		}
-		if !query.IncludeCancelled &&
-			(jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
-				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut")) {
-			matching = false
+		if query.Cancelled {
+			if jobOffer.State != data.GetAgreementStateIndex("JobOfferCancelled") &&
+				jobOffer.State != data.GetAgreementStateIndex("JobTimedOut") {
+				matching = false
+			}
+		} else if !query.IncludeCancelled {
+			if jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
+				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut") {
+				matching = false
+			}
 		}
 		if matching {
 			jobOffers = append(jobOffers, *jobOffer)

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -105,6 +105,12 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 				matching = false
 			}
 		}
+		if query.Active &&
+			jobOffer.State != data.GetAgreementStateIndex("DealNegotiating") &&
+			jobOffer.State != data.GetAgreementStateIndex("DealAgreed") &&
+			jobOffer.State != data.GetAgreementStateIndex("ResultsSubmitted") {
+			matching = false
+		}
 		if !query.IncludeCancelled && jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") {
 			matching = false
 		}

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -111,15 +111,18 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 			jobOffer.State != data.GetAgreementStateIndex("ResultsSubmitted") {
 			matching = false
 		}
-		if query.Cancelled {
-			if jobOffer.State != data.GetAgreementStateIndex("JobOfferCancelled") &&
-				jobOffer.State != data.GetAgreementStateIndex("JobTimedOut") {
-				matching = false
-			}
-		} else if !query.IncludeCancelled {
-			if jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
-				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut") {
-				matching = false
+		if query.Cancelled != nil {
+			isCancelled := jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
+				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut")
+
+			if *query.Cancelled {
+				if !isCancelled {
+					matching = false
+				}
+			} else {
+				if isCancelled {
+					matching = false
+				}
 			}
 		}
 		if matching {

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -111,7 +111,9 @@ func (s *SolverStoreMemory) GetJobOffers(query store.GetJobOffersQuery) ([]data.
 			jobOffer.State != data.GetAgreementStateIndex("ResultsSubmitted") {
 			matching = false
 		}
-		if !query.IncludeCancelled && jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") {
+		if !query.IncludeCancelled &&
+			(jobOffer.State == data.GetAgreementStateIndex("JobOfferCancelled") ||
+				jobOffer.State == data.GetAgreementStateIndex("JobTimedOut")) {
 			matching = false
 		}
 		if matching {

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -24,11 +24,9 @@ type GetJobOffersQuery struct {
 	// This includes the DealNegotiating, DealAgreed, or ResultsSubmitted states.
 	Active bool `json:"in_progress"`
 
-	// Cancelled job offers are in a JobOfferCancelled or JobTimedOut state
-	Cancelled bool `json:"cancelled"`
-
-	// this will include cancelled job offers in the results
-	IncludeCancelled bool `json:"include_cancelled"`
+	// Cancelled job offers are in a JobOfferCancelled or JobTimedOut state.
+	// All job offers are included when Cancelled is nil.
+	Cancelled *bool `json:"cancelled"`
 
 	// Sort job offers oldest first
 	OrderOldestFirst bool `json:"order_oldest_first"`

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -24,6 +24,9 @@ type GetJobOffersQuery struct {
 	// This includes the DealNegotiating, DealAgreed, or ResultsSubmitted states.
 	Active bool `json:"in_progress"`
 
+	// Cancelled job offers are in a JobOfferCancelled or JobTimedOut state
+	Cancelled bool `json:"cancelled"`
+
 	// this will include cancelled job offers in the results
 	IncludeCancelled bool `json:"include_cancelled"`
 

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -20,6 +20,10 @@ type GetJobOffersQuery struct {
 	// we use the DealID property of the jobOfferContainer to tell if it's been matched
 	NotMatched bool `json:"not_matched"`
 
+	// Active job offers are umatched or in an in-progress deal.
+	// This includes the DealNegotiating, DealAgreed, or ResultsSubmitted states.
+	Active bool `json:"in_progress"`
+
 	// this will include cancelled job offers in the results
 	IncludeCancelled bool `json:"include_cancelled"`
 

--- a/pkg/solver/store/store_test.go
+++ b/pkg/solver/store/store_test.go
@@ -267,6 +267,36 @@ func TestJobOfferQuery(t *testing.T) {
 			},
 		},
 		{
+			name: "filter cancelled offers only",
+			offers: []data.JobOfferContainer{
+				{
+					ID:         "QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetDefaultAgreementState(),
+				},
+				{
+					ID:         "QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("JobOfferCancelled"),
+				},
+				{
+					ID:         "QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("JobTimedOut"),
+				},
+			},
+			query: store.GetJobOffersQuery{
+				Cancelled: true,
+			},
+			expected: []string{
+				"QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+				"QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+			},
+		},
+		{
 			name: "combined filters",
 			offers: []data.JobOfferContainer{
 				{

--- a/pkg/solver/store/store_test.go
+++ b/pkg/solver/store/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	solverstore "github.com/lilypad-tech/lilypad/pkg/solver/store"
+	"github.com/lilypad-tech/lilypad/pkg/system"
 	"golang.org/x/exp/rand"
 )
 
@@ -159,7 +160,7 @@ func TestJobOfferQuery(t *testing.T) {
 				},
 			},
 			query: store.GetJobOffersQuery{
-				IncludeCancelled: false,
+				Cancelled: system.BoolPointer(false),
 			},
 			expected: []string{"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx"},
 		},
@@ -258,7 +259,7 @@ func TestJobOfferQuery(t *testing.T) {
 				},
 			},
 			query: store.GetJobOffersQuery{
-				IncludeCancelled: true,
+				Cancelled: nil,
 			},
 			expected: []string{
 				"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
@@ -289,7 +290,7 @@ func TestJobOfferQuery(t *testing.T) {
 				},
 			},
 			query: store.GetJobOffersQuery{
-				Cancelled: true,
+				Cancelled: system.BoolPointer(true),
 			},
 			expected: []string{
 				"QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
@@ -325,9 +326,9 @@ func TestJobOfferQuery(t *testing.T) {
 				},
 			},
 			query: store.GetJobOffersQuery{
-				JobCreator:       "0x1234567890123456789012345678901234567890",
-				NotMatched:       true,
-				IncludeCancelled: false,
+				JobCreator: "0x1234567890123456789012345678901234567890",
+				NotMatched: true,
+				Cancelled:  system.BoolPointer(false),
 			},
 			expected: []string{"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx"},
 		},

--- a/pkg/solver/store/store_test.go
+++ b/pkg/solver/store/store_test.go
@@ -158,6 +158,78 @@ func TestJobOfferQuery(t *testing.T) {
 			expected: []string{"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx"},
 		},
 		{
+			name: "filter active offers",
+			offers: []data.JobOfferContainer{
+				{
+					ID:         "QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("DealNegotiating"),
+				},
+				{
+					ID:         "QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "QmV8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ku",
+					State:      data.GetAgreementStateIndex("DealAgreed"),
+				},
+				{
+					ID:         "QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("ResultsSubmitted"),
+				},
+				{
+					ID:         "QmW9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kw",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("ResultsAccepted"),
+				},
+			},
+			query: store.GetJobOffersQuery{
+				Active: true,
+			},
+			expected: []string{
+				"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
+				"QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+				"QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+			},
+		},
+		{
+			name: "combined filters with active",
+			offers: []data.JobOfferContainer{
+				{
+					ID:         "QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("DealNegotiating"),
+				},
+				{
+					ID:         "QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+					JobCreator: "0xabcdef0123456789abcdef0123456789abcdef01",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("DealNegotiating"),
+				},
+				{
+					ID:         "QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "QmW9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kw",
+					State:      data.GetAgreementStateIndex("DealAgreed"),
+				},
+				{
+					ID:         "QmV9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kv",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "QmU8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kt",
+					State:      data.GetAgreementStateIndex("ResultsAccepted"),
+				},
+			},
+			query: store.GetJobOffersQuery{
+				JobCreator: "0x1234567890123456789012345678901234567890",
+				NotMatched: true,
+				Active:     true,
+			},
+			expected: []string{"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx"},
+		},
+		{
 			name: "include cancelled offers",
 			offers: []data.JobOfferContainer{
 				{

--- a/pkg/solver/store/store_test.go
+++ b/pkg/solver/store/store_test.go
@@ -151,6 +151,12 @@ func TestJobOfferQuery(t *testing.T) {
 					DealID:     "",
 					State:      data.GetAgreementStateIndex("JobOfferCancelled"),
 				},
+				{
+					ID:         "QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("JobTimedOut"),
+				},
 			},
 			query: store.GetJobOffersQuery{
 				IncludeCancelled: false,
@@ -244,6 +250,12 @@ func TestJobOfferQuery(t *testing.T) {
 					DealID:     "",
 					State:      data.GetAgreementStateIndex("JobOfferCancelled"),
 				},
+				{
+					ID:         "QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
+					JobCreator: "0x1234567890123456789012345678901234567890",
+					DealID:     "",
+					State:      data.GetAgreementStateIndex("JobTimedOut"),
+				},
 			},
 			query: store.GetJobOffersQuery{
 				IncludeCancelled: true,
@@ -251,6 +263,7 @@ func TestJobOfferQuery(t *testing.T) {
 			expected: []string{
 				"QmY8JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kx",
 				"QmX9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Ky",
+				"QmZ9JwJh3bYDUuAnwfpxwStjUY1nQwyhJJ4SPpdV3bZ9Kz",
 			},
 		},
 		{

--- a/pkg/solver/testing.go
+++ b/pkg/solver/testing.go
@@ -59,9 +59,7 @@ func SetupTestStores(t *testing.T) []TestStoreConfig {
 
 func clearStoreDatabase(t *testing.T, s store.SolverStore) {
 	// Delete job offers
-	jobOffers, err := s.GetJobOffers(store.GetJobOffersQuery{
-		IncludeCancelled: true,
-	})
+	jobOffers, err := s.GetJobOffers(store.GetJobOffersQuery{})
 	if err != nil {
 		t.Fatalf("Failed to get existing job offers: %v", err)
 	}

--- a/pkg/solver/testing.go
+++ b/pkg/solver/testing.go
@@ -124,4 +124,17 @@ func clearStoreDatabase(t *testing.T, s store.SolverStore) {
 			t.Fatalf("Failed to remove existing match decision: %v", err)
 		}
 	}
+
+	// Delete allowed resource providers
+	providers, err := s.GetAllowedResourceProviders()
+	if err != nil {
+		t.Fatalf("Failed to get existing allowed resource providers: %v", err)
+	}
+
+	for _, provider := range providers {
+		err := s.RemoveAllowedResourceProvider(provider)
+		if err != nil {
+			t.Fatalf("Failed to remove existing allowed resource provider: %v", err)
+		}
+	}
 }

--- a/pkg/system/lang.go
+++ b/pkg/system/lang.go
@@ -1,0 +1,5 @@
+package system
+
+func BoolPointer(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add expired job cancellation to the solver control loop
  - [x] Add `JOB_TIMEOUT_SECONDS` config
  - [x] Add `JobTimedOut` terminal agreement state
  - [x] Add cancelled job metrics 
  - [x] Add cancelled job traces
- [x] Add `Active` job offer query filter
- [x] Add `Cancelled` job offer query filter
  - [x] Remove `IncludeCancelled` filter and integrate it into `Cancelled` 

We have also made a couple of related changes and small cleanups:

- [x] Rename deal stats metrics to job stats metrics
- [x] Record job stat metrics for cancelled job offers that are not involved in a deal
- [x] Clean up allowed resource providers between test runs. We missed it while rebasing #481.
- [x] Update comments in solver `solve` function
- [x] Add `BoolPointer` language helper to more easily construct pointers to bools

The primary goal of this pull request is adding a global job timeout for jobs that are stuck, stale, or abandoned. The global timeout will be superseded by timeouts in module specs and job offers when we have implemented them.

We have also added new `Active` and `Cancelled` job offer query filters in support of the global timeout.

### Task/Issue reference

Closes: #511

### Test plan

Start the base services. Start the solver with the job offer timeout set to ten seconds:

```
./stack solver --job-timeout-seconds 10
```

Submit a job without a resource provider running. The job should fail and report a job timed out error message.

Start a resource provider and run another job. Again, the job should be cancelled, but this time in flight. The job creator should see the error message and the resource provider should repost their resource offer.

See the details below if you would like to confirm the activity through metrics and traces.

### Details

**`Active` and `Cancelled` job offer filter queries**

We have added two new job offer filter queries. 

When `Active` is `true`, only jobs in `DealNegotiating`, `DealAgreed`, or `ResultsSubmitted` states are included.

Query active job offers from the solver server with the `active` querstring param. In local development:

```sh
curl http://localhost:8081/api/v1/job_offers?active=true
```

The `Cancelled` query filter is a `*bool` where:

- `nil` includes all jobs
- `true` includes jobs in `JobOfferCancelled` and `JobTimedOut` states
- `false` includes jobs _not_ in a `JobOfferCancelled` or `JobTimedOut` state

We removed the `IncludeCancelled` filter query which is now performed when `Cancelled` is `nil`.

Query jobs on the solver server using the `cancelled` querystring param. In local development:

```sh
curl http://localhost:8081/api/v1/job_offers                    # all jobs
curl http://localhost:8081/api/v1/job_offers?cancelled=true     # cancelled jobs   
curl http://localhost:8081/api/v1/job_offers?cancelled=false    # not cancelled jobs
```

**`JobTimedOut` agreement state**

We have added a new `JobTimedOut` agreement state to describe jobs that were cancelled because they expired. 

We considered using the existing `JobOfferCancelled` state, but it is not coherent when we want to mark resource offers and deals with an expired state. In addition, our mechanism for reporting what happened to the job creator is limited, so `JobTimedOut` serves as a tag to help us log a good error message for the job creator.

When a job times out before a deal was made, the job offer is marked with the `JobTimedOut` state. When a deal has already been made, the job offer, resource offer, and deal are all marked with the `JobTimedOut` state.

If a resource provider attempts to upload files or report results for an expired job, the solver server rejects their post with an error reporting the job as timed out.

**`JOB_TIMEOUT_SECONDS` config**

We have added a new config to set the global timeout in seconds. The default value is ten minutes.

Set the job timeout with an environment variable of CLI option. For example, to expire jobs after 30 seconds:

```
./stack solver --job-timeout-seconds 30
JOB_TIMEOUT_SECONDS=30 ./stack solver
```

**Observability**

The deal metrics have been updated to reflect overall job metrics. We want to include metrics about job offers that were never in a deal, and we record these from jobs that expired or were cancelled.

The metrics are reported in an updated `Solver Metrics` dashboard:

![timed-out-metrics](https://github.com/user-attachments/assets/bbeb3590-b9f3-4248-bdd1-d2732ac80efb)

The updated dashboard is available in this observability pull request: https://github.com/Lilypad-Tech/observability/pull/27

Metrics are not enabled by default in local development, but they can be turned on with:

```sh
export ENABLE_METRICS=true
export METRICS_URL="http://localhost:8500"
export METRICS_TOKEN="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkIjp0cnVlLCJ1c2VyIjoicmVzb3VyY2UtcHJvdmlkZXIifQ.n36M_ngwC4XPQ_pEkkWAnPiOinnx6-0VO1v_WgCTUEERD7b_p9KHCU6SY5bUdFh5UXRZHAhc1gfyc7rjAnmeDQ"
  ```

We have also included traces over our new `cancelExpiredJobs` solver controller function. Traces are also disabled by default in local development, but can be enabled with the `--disable-telemetry=false` CLI option.

The traces can be queried by searching TraceQL with the `cancel_expired_jobs` span name and a non-empty expired jobs span attribute:

```
{name="cancel_expired_jobs" && span.expired_job_offers!="[]"}
```

When a job is cancelled before a match, the trace will look like:

![cancelled-before-match-trace](https://github.com/user-attachments/assets/40270442-c63b-4c3e-91c8-548fe6a0d779)

If a job is cancelled after a match, it will also report a deal ID:

![cancelled-post-match](https://github.com/user-attachments/assets/b5a8be2b-d0e6-46b0-986e-6453f3fa61ec)

### Related issues or PRs

Observability dashboard PR: https://github.com/Lilypad-Tech/observability/pull/27

