### PR TITLE
feat: Add job run stats reporting

### DIFF
--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -68,7 +68,7 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string)
 		return err
 	}
 
-	stats, err := stats.NewStats(options.Stats)
+	stats, err := stats.NewStats(system.SolverService, options.Stats, options.Web3, web3SDK)
 	if err != nil {
 		return err
 	}

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -5,6 +5,7 @@ import (
 
 	optionsfactory "github.com/lilypad-tech/lilypad/pkg/options"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
+	"github.com/lilypad-tech/lilypad/pkg/solver/stats"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	db "github.com/lilypad-tech/lilypad/pkg/solver/store/db"
 	memorystore "github.com/lilypad-tech/lilypad/pkg/solver/store/memory"
@@ -67,7 +68,12 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string)
 		return err
 	}
 
-	solverService, err := solver.NewSolver(options, solverStore, web3SDK, tracer, meter)
+	stats, err := stats.NewStats(options.Stats)
+	if err != nil {
+		return err
+	}
+
+	solverService, err := solver.NewSolver(options, solverStore, web3SDK, stats, tracer, meter)
 	if err != nil {
 		return err
 	}

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -162,7 +162,8 @@ type TargetConfig struct {
 type JobOffer struct {
 	// this is the cid of the job offer where ID is set to empty string
 	ID string `json:"id"`
-	// this is basically a nonce so we don't have one ID pointing at multiple offers
+	// Acts as a nonce so we don't have one ID pointing at multiple offers.
+	// Also used as the starting time when recording job run times.
 	CreatedAt int `json:"created_at"`
 	// the address of the job creator
 	JobCreator string `json:"job_creator"`

--- a/pkg/module/shortcuts/shortcuts.go
+++ b/pkg/module/shortcuts/shortcuts.go
@@ -45,3 +45,7 @@ func GetModule(name string) (data.ModuleConfig, error) {
 
 	return module, nil
 }
+
+func GetShortcut(repo string, hash string) string {
+	return fmt.Sprintf("%s:%s", repo, hash)
+}

--- a/pkg/options/solver.go
+++ b/pkg/options/solver.go
@@ -14,6 +14,7 @@ func NewSolverOptions() solver.SolverOptions {
 		Store:             GetDefaultStoreOptions(),
 		Web3:              GetDefaultWeb3Options(),
 		Services:          GetDefaultServicesOptions(),
+		Stats:             GetDefaultStatsOptions(),
 		Telemetry:         GetDefaultTelemetryOptions(),
 		Metrics:           GetDefaultMetricsOptions(),
 		JobTimeoutSeconds: GetDefaultServeOptionInt("JOB_TIMEOUT_SECONDS", 600), // 10 minutes
@@ -27,6 +28,7 @@ func AddSolverCliFlags(cmd *cobra.Command, options *solver.SolverOptions) {
 	AddStoreCliFlags(cmd, &options.Store)
 	AddWeb3CliFlags(cmd, &options.Web3)
 	AddServicesCliFlags(cmd, &options.Services)
+	AddStatsCliFlags(cmd, &options.Stats)
 	AddTelemetryCliFlags(cmd, &options.Telemetry)
 	AddMetricsCliFlags(cmd, &options.Metrics)
 	cmd.PersistentFlags().IntVar(
@@ -45,6 +47,10 @@ func CheckSolverOptions(options solver.SolverOptions) error {
 		return err
 	}
 	err = CheckWeb3Options(options.Web3)
+	if err != nil {
+		return err
+	}
+	err = CheckStatsOptions(options.Stats)
 	if err != nil {
 		return err
 	}

--- a/pkg/options/stats.go
+++ b/pkg/options/stats.go
@@ -1,0 +1,39 @@
+package options
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lilypad-tech/lilypad/pkg/solver/stats"
+	"github.com/spf13/cobra"
+)
+
+func GetDefaultStatsOptions() stats.StatsOptions {
+	return stats.StatsOptions{
+		Enabled: GetDefaultServeOptionBool("ENABLE_STATS", false),
+		URL:     GetDefaultServeOptionString("STATS_URL", ""),
+	}
+}
+
+func AddStatsCliFlags(cmd *cobra.Command, statsOptions *stats.StatsOptions) {
+	cmd.PersistentFlags().BoolVar(
+		&statsOptions.Enabled, "enable-stats", statsOptions.Enabled,
+		`Enable stats (ENABLE_STATS)`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&statsOptions.URL, "stats-url", statsOptions.URL,
+		`The stats endpoint to connect to (STATS_URL).`,
+	)
+}
+
+func CheckStatsOptions(options stats.StatsOptions) error {
+	if options.Enabled {
+		if options.URL == "" {
+			return fmt.Errorf("STATS_URL must be set when using the stats API")
+		}
+		if _, err := url.ParseRequestURI(options.URL); err != nil {
+			return fmt.Errorf("Invalid STATS_URL format: %v", err)
+		}
+	}
+	return nil
+}

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -605,6 +605,7 @@ func (solverServer *solverServer) handleFileDownload(dirPath string, res corehtt
 	for _, file := range files {
 		info, err := file.Info()
 		if err != nil {
+			log.Warn().Msgf("expected file renamed or moved: %v", err)
 			continue
 		}
 		if info.Mode().IsRegular() {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -577,6 +577,11 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 
 	if err := solverServer.handleFileDownload(GetDealsFilePath(id), res, func() {
 		solverServer.stats.PostJobRun(solverServer.store, deal)
+		solverServer.stats.PostReputation(deal.ResourceProvider,
+			stats.NewReputationBuilder().
+				WithJobCompletedNoValidation(true).
+				Build(),
+		)
 	}); err != nil {
 		return EmptyResponse{}, err
 	}
@@ -777,6 +782,11 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 
 	if err := solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res, func() {
 		solverServer.stats.PostJobRun(solverServer.store, deal)
+		solverServer.stats.PostReputation(deal.ResourceProvider,
+			stats.NewReputationBuilder().
+				WithJobCompletedNoValidation(true).
+				Build(),
+		)
 	}); err != nil {
 		return EmptyResponse{}, err
 	}

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -81,7 +81,7 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 	subrouter.HandleFunc("/job_offers", http.PostHandler(solverServer.addJobOffer)).Methods("POST")
 
 	subrouter.HandleFunc("/job_offers/{id}", http.GetHandler(solverServer.getJobOffer)).Methods("GET")
-	subrouter.HandleFunc("/job_offers/{id}/files", solverServer.jobOfferDownloadFiles).Methods("GET")
+	subrouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(solverServer.jobOfferDownloadFiles)).Methods("GET")
 
 	subrouter.HandleFunc("/resource_offers", http.GetHandler(solverServer.getResourceOffers)).Methods("GET")
 	subrouter.HandleFunc("/resource_offers", http.PostHandler(solverServer.addResourceOffer)).Methods("POST")
@@ -89,7 +89,7 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 	subrouter.HandleFunc("/deals", http.GetHandler(solverServer.getDeals)).Methods("GET")
 	subrouter.HandleFunc("/deals/{id}", http.GetHandler(solverServer.getDeal)).Methods("GET")
 
-	subrouter.HandleFunc("/deals/{id}/files", solverServer.downloadFiles).Methods("GET")
+	subrouter.HandleFunc("/deals/{id}/files", http.GetHandler(solverServer.downloadFiles)).Methods("GET")
 	subrouter.HandleFunc("/deals/{id}/files", solverServer.uploadFiles).Methods("POST")
 
 	subrouter.HandleFunc("/deals/{id}/result", http.GetHandler(solverServer.getResult)).Methods("GET")
@@ -121,7 +121,7 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 	anurarouter.HandleFunc("/job_offers", http.PostHandler(solverServer.addJobOffer)).Methods("POST")
 	anurarouter.HandleFunc("/job_offers", http.GetHandler(solverServer.getJobOffers)).Methods("GET")
 	anurarouter.HandleFunc("/job_offers/{id}", http.GetHandler(solverServer.getJobOffer)).Methods("GET")
-	anurarouter.HandleFunc("/job_offers/{id}/files", solverServer.jobOfferDownloadFiles).Methods("GET")
+	anurarouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(solverServer.jobOfferDownloadFiles)).Methods("GET")
 
 	// this will fan out to all connected web socket connections
 	// we read all events coming from inside the solver controller
@@ -535,50 +535,105 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 *
 */
 
-func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
+type EmptyResponse struct{}
+
+func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
 
-	err := func() *http.HTTPError {
-		deal, err := solverServer.store.GetDeal(id)
-		if err != nil {
-			log.Error().Err(err).Msgf("error loading deal")
-			return &http.HTTPError{
-				Message:    err.Error(),
-				StatusCode: corehttp.StatusInternalServerError,
-			}
-		}
-		if deal == nil {
-			return &http.HTTPError{
-				Message:    err.Error(),
-				StatusCode: corehttp.StatusNotFound,
-			}
-		}
-
-		signerAddress, err := http.CheckSignature(req)
-		if err != nil {
-			log.Error().Err(err).Msgf("error checking signature")
-			return &http.HTTPError{
-				Message:    errors.New("not authorized").Error(),
-				StatusCode: corehttp.StatusUnauthorized,
-			}
-		}
-		// Only the job creator in a deal can download job outputs
-		if signerAddress != deal.JobCreator {
-			log.Error().Err(err).Msgf("job creator address does not match signer address")
-			return &http.HTTPError{
-				Message:    errors.New("not authorized").Error(),
-				StatusCode: corehttp.StatusUnauthorized,
-			}
-		}
-		return solverServer.handleFileDownload(GetDealsFilePath(deal.ID), res)
-	}()
-
+	// Get the deal
+	deal, err := solverServer.store.GetDeal(id)
 	if err != nil {
-		log.Ctx(req.Context()).Error().Msgf("error for route: %s", err.Error())
-		corehttp.Error(res, err.Error(), err.StatusCode)
-		return
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    "error loading deal",
+			StatusCode: corehttp.StatusInternalServerError,
+		}
 	}
+	if deal == nil {
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    "deal not found",
+			StatusCode: corehttp.StatusNotFound,
+		}
+	}
+
+	// Check authorization
+	signerAddress, err := http.CheckSignature(req)
+	if err != nil {
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    "not authorized",
+			StatusCode: corehttp.StatusUnauthorized,
+		}
+	}
+	if signerAddress != deal.JobCreator {
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    "not authorized: job creator address does not match signer address",
+			StatusCode: corehttp.StatusUnauthorized,
+		}
+	}
+
+	if err := solverServer.handleFileDownload(GetDealsFilePath(id), res); err != nil {
+		return EmptyResponse{}, err
+	}
+
+	return EmptyResponse{}, nil
+}
+
+func (solverServer *solverServer) handleFileDownload(dirPath string, res corehttp.ResponseWriter) *http.HTTPError {
+	// Read directory contents
+	files, err := os.ReadDir(dirPath)
+	if err != nil {
+		return &http.HTTPError{
+			Message:    fmt.Sprintf("error reading directory: %s", err.Error()),
+			StatusCode: corehttp.StatusNotFound,
+		}
+	}
+
+	// Find the first regular file
+	var targetFile os.DirEntry
+	for _, file := range files {
+		info, err := file.Info()
+		if err != nil {
+			continue
+		}
+		if info.Mode().IsRegular() {
+			targetFile = file
+			break
+		}
+	}
+
+	if targetFile == nil {
+		return &http.HTTPError{
+			Message:    "no regular files found in directory",
+			StatusCode: corehttp.StatusNotFound,
+		}
+	}
+
+	// Get the actual filename and path
+	filename := targetFile.Name()
+	filePath := filepath.Join(dirPath, filename)
+
+	// Open and serve the file
+	file, err := os.Open(filePath)
+	if err != nil {
+		return &http.HTTPError{
+			Message:    err.Error(),
+			StatusCode: corehttp.StatusInternalServerError,
+		}
+	}
+	defer file.Close()
+
+	res.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+	res.Header().Set("Content-Type", "application/x-tar")
+
+	_, err = io.Copy(res, file)
+	if err != nil {
+		return &http.HTTPError{
+			Message:    err.Error(),
+			StatusCode: corehttp.StatusInternalServerError,
+		}
+	}
+
+	return nil
 }
 
 func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
@@ -660,110 +715,49 @@ func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *
 	}
 }
 
-func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
+func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
 
-	err := func() *http.HTTPError {
-		jobOffer, err := solverServer.store.GetJobOffer(id)
-		if err != nil {
-			log.Error().Err(err).Msgf("error loading job offer")
-			return &http.HTTPError{
-				Message:    err.Error(),
-				StatusCode: corehttp.StatusInternalServerError,
-			}
-		}
-		if jobOffer == nil {
-			return &http.HTTPError{
-				Message:    err.Error(),
-				StatusCode: corehttp.StatusNotFound,
-			}
-		}
-
-		signerAddress, err := http.CheckSignature(req)
-		if err != nil {
-			log.Error().Err(err).Msgf("error checking signature")
-			return &http.HTTPError{
-				Message:    errors.New("not authorized").Error(),
-				StatusCode: corehttp.StatusUnauthorized,
-			}
-		}
-
-		if signerAddress != jobOffer.JobCreator {
-			log.Error().Err(err).Msgf("job creator address does not match signer address")
-			return &http.HTTPError{
-				Message:    errors.New("not authorized").Error(),
-				StatusCode: corehttp.StatusUnauthorized,
-			}
-		}
-
-		solverServer.updateJobStates(jobOffer.DealID, "ResultsAccepted")
-
-		return solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res)
-	}()
-
+	jobOffer, err := solverServer.store.GetJobOffer(id)
 	if err != nil {
-		log.Ctx(req.Context()).Error().Msgf("error for route: %s", err.Error())
-		corehttp.Error(res, err.Error(), err.StatusCode)
-	}
-}
-
-func (solverServer *solverServer) handleFileDownload(dirPath string, res corehttp.ResponseWriter) *http.HTTPError {
-	// Read directory contents
-	files, err := os.ReadDir(dirPath)
-	if err != nil {
-		return &http.HTTPError{
-			Message:    fmt.Sprintf("error reading directory: %s", err.Error()),
-			StatusCode: corehttp.StatusNotFound,
-		}
-	}
-
-	// Find the first regular file
-	var targetFile os.DirEntry
-	for _, file := range files {
-		info, err := file.Info()
-		if err != nil {
-			continue
-		}
-		if info.Mode().IsRegular() {
-			targetFile = file
-			break
-		}
-	}
-
-	if targetFile == nil {
-		return &http.HTTPError{
-			Message:    "no regular files found in directory",
-			StatusCode: corehttp.StatusNotFound,
-		}
-	}
-
-	// Get the actual filename and path
-	filename := targetFile.Name()
-	filePath := filepath.Join(dirPath, filename)
-
-	// Open and serve the file
-	file, err := os.Open(filePath)
-	if err != nil {
-		return &http.HTTPError{
+		log.Error().Err(err).Msgf("error loading job offer")
+		return EmptyResponse{}, &http.HTTPError{
 			Message:    err.Error(),
 			StatusCode: corehttp.StatusInternalServerError,
 		}
 	}
-	defer file.Close()
-
-	res.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
-	res.Header().Set("Content-Type", "application/x-tar")
-
-	_, err = io.Copy(res, file)
-	if err != nil {
-		return &http.HTTPError{
+	if jobOffer == nil {
+		return EmptyResponse{}, &http.HTTPError{
 			Message:    err.Error(),
-			StatusCode: corehttp.StatusInternalServerError,
+			StatusCode: corehttp.StatusNotFound,
 		}
 	}
 
-	return nil
+	signerAddress, err := http.CheckSignature(req)
+	if err != nil {
+		log.Error().Err(err).Msgf("error checking signature")
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    errors.New("not authorized").Error(),
+			StatusCode: corehttp.StatusUnauthorized,
+		}
+	}
+
+	if signerAddress != jobOffer.JobCreator {
+		log.Error().Err(err).Msgf("job creator address does not match signer address")
+		return EmptyResponse{}, &http.HTTPError{
+			Message:    errors.New("not authorized").Error(),
+			StatusCode: corehttp.StatusUnauthorized,
+		}
+	}
+
+	solverServer.updateJobStates(jobOffer.DealID, "ResultsAccepted")
+
+	if err := solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res); err != nil {
+		return EmptyResponse{}, err
+	}
+
+	return EmptyResponse{}, nil
 }
 
 // Validation Service

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/lilypad-tech/lilypad/pkg/metricsDashboard"
+	"github.com/lilypad-tech/lilypad/pkg/solver/stats"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/rs/zerolog/log"
@@ -32,6 +33,7 @@ type solverServer struct {
 	options    http.ServerOptions
 	controller *SolverController
 	store      store.SolverStore
+	stats      stats.Stats
 	services   data.ServiceConfig
 }
 
@@ -39,12 +41,14 @@ func NewSolverServer(
 	options http.ServerOptions,
 	controller *SolverController,
 	store store.SolverStore,
+	stats stats.Stats,
 	services data.ServiceConfig,
 ) (*solverServer, error) {
 	server := &solverServer{
 		options:    options,
 		controller: controller,
 		store:      store,
+		stats:      stats,
 	}
 
 	metricsDashboard.Init(services.APIHost)

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -539,6 +539,8 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 *
 */
 
+// We use EmptyResponse to provide a type for the http.GetHandler wrapper,
+// but the client expects a file stream and will ignore it.
 type EmptyResponse struct{}
 
 func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -579,7 +579,7 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 	}
 
 	if err := solverServer.handleFileDownload(GetDealsFilePath(id), res, func() {
-		solverServer.stats.PostJobRun(solverServer.store, deal)
+		solverServer.stats.PostJobRun(deal)
 		solverServer.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).
@@ -785,7 +785,7 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 	}
 
 	if err := solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res, func() {
-		solverServer.stats.PostJobRun(solverServer.store, deal)
+		solverServer.stats.PostJobRun(deal)
 		solverServer.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -569,6 +569,7 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 		}
 	}
 	if signerAddress != deal.JobCreator {
+		log.Debug().Msgf("signer address %s does not match job creator address %s", signerAddress, deal.JobCreator)
 		return EmptyResponse{}, &http.HTTPError{
 			Message:    "not authorized: job creator address does not match signer address",
 			StatusCode: corehttp.StatusUnauthorized,
@@ -756,7 +757,7 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 	}
 
 	if signerAddress != jobOffer.JobCreator {
-		log.Error().Err(err).Msgf("job creator address does not match signer address")
+		log.Debug().Msgf("signer address %s does not match job creator address %s", signerAddress, jobOffer.JobCreator)
 		return EmptyResponse{}, &http.HTTPError{
 			Message:    errors.New("not authorized").Error(),
 			StatusCode: corehttp.StatusUnauthorized,

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
+	"github.com/lilypad-tech/lilypad/pkg/solver/stats"
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
@@ -19,6 +20,7 @@ type SolverOptions struct {
 	Store             store.StoreOptions
 	Web3              web3.Web3Options
 	Services          data.ServiceConfig
+	Stats             stats.StatsOptions
 	Telemetry         system.TelemetryOptions
 	Metrics           system.MetricsOptions
 	JobTimeoutSeconds int

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -31,6 +31,7 @@ type Solver struct {
 	server     *solverServer
 	controller *SolverController
 	store      store.SolverStore
+	stats      stats.Stats
 	options    SolverOptions
 }
 
@@ -38,6 +39,7 @@ func NewSolver(
 	options SolverOptions,
 	store store.SolverStore,
 	web3SDK *web3.Web3SDK,
+	stats stats.Stats,
 	tracer trace.Tracer,
 	meter metric.Meter,
 ) (*Solver, error) {
@@ -45,7 +47,7 @@ func NewSolver(
 	if err != nil {
 		return nil, err
 	}
-	server, err := NewSolverServer(options.Server, controller, store, options.Services)
+	server, err := NewSolverServer(options.Server, controller, store, stats, options.Services)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/solver/stats/jobrun.go
+++ b/pkg/solver/stats/jobrun.go
@@ -1,0 +1,67 @@
+package stats
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lilypad-tech/lilypad/pkg/data"
+	"github.com/lilypad-tech/lilypad/pkg/http"
+	"github.com/lilypad-tech/lilypad/pkg/module/shortcuts"
+	"github.com/lilypad-tech/lilypad/pkg/solver/store"
+	"github.com/rs/zerolog/log"
+)
+
+type JobRun struct {
+	DealID                    string          `json:"dealId"`
+	ModuleID                  string          `json:"moduleId"`
+	ResourceProvider          string          `json:"resourceProvider"`
+	JobCreator                string          `json:"jobCreator"`
+	TotalDurationMilliseconds float64         `json:"totalDuration_ms"`
+	ExtraData                 json.RawMessage `json:"extraData"`
+	JobOffer                  string          `json:"jobOffer"`
+	ResourceOffer             string          `json:"resourceOffer"`
+}
+
+// Stats API implementation
+
+func (stat *HTTPStats) PostJobRun(store store.SolverStore, deal *data.DealContainer) error {
+	jobOffer, err := store.GetJobOffer(deal.Deal.JobOffer.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to get job offer")
+		return err
+	}
+	jobRunTime := time.Now().UnixMilli() - int64(jobOffer.JobOffer.CreatedAt)
+
+	extraData, err := json.Marshal(map[string]string{
+		"state": data.GetAgreementStateString(deal.State),
+	})
+	if err != nil {
+		log.Error().Msgf("unable to marshal extra data: %s", err)
+		return err
+	}
+
+	jobRun := JobRun{
+		DealID:                    deal.ID,
+		ModuleID:                  shortcuts.GetShortcut(deal.Deal.JobOffer.Module.Repo, deal.Deal.JobOffer.Module.Hash),
+		ResourceProvider:          deal.ResourceProvider,
+		JobCreator:                deal.JobCreator,
+		TotalDurationMilliseconds: float64(jobRunTime),
+		ExtraData:                 extraData,
+		JobOffer:                  deal.JobOffer,
+		ResourceOffer:             deal.ResourceOffer,
+	}
+
+	_, err = http.PostRequest[JobRun, JobRun](stat.ClientOptions, "/job-run", jobRun)
+	if err != nil {
+		return fmt.Errorf("failed to post job run: %s", err)
+	}
+
+	return nil
+}
+
+// Noop implementation
+
+func (stat *NoopStats) PostJobRun(store store.SolverStore, deal *data.DealContainer) error {
+	return nil
+}

--- a/pkg/solver/stats/jobrun.go
+++ b/pkg/solver/stats/jobrun.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/lilypad-tech/lilypad/pkg/module/shortcuts"
-	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/rs/zerolog/log"
 )
 
@@ -25,14 +24,8 @@ type JobRun struct {
 
 // Stats API implementation
 
-func (stat *HTTPStats) PostJobRun(store store.SolverStore, deal *data.DealContainer) error {
-	jobOffer, err := store.GetJobOffer(deal.Deal.JobOffer.ID)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to get job offer")
-		return err
-	}
-	jobRunTime := time.Now().UnixMilli() - int64(jobOffer.JobOffer.CreatedAt)
-
+func (stat *HTTPStats) PostJobRun(deal *data.DealContainer) error {
+	jobRunTime := time.Now().UnixMilli() - int64(deal.Deal.JobOffer.CreatedAt)
 	extraData, err := json.Marshal(map[string]string{
 		"state": data.GetAgreementStateString(deal.State),
 	})
@@ -62,6 +55,6 @@ func (stat *HTTPStats) PostJobRun(store store.SolverStore, deal *data.DealContai
 
 // Noop implementation
 
-func (stat *NoopStats) PostJobRun(store store.SolverStore, deal *data.DealContainer) error {
+func (stat *NoopStats) PostJobRun(deal *data.DealContainer) error {
 	return nil
 }

--- a/pkg/solver/stats/reputation.go
+++ b/pkg/solver/stats/reputation.go
@@ -1,0 +1,69 @@
+package stats
+
+import (
+	"fmt"
+
+	"github.com/lilypad-tech/lilypad/pkg/http"
+)
+
+type Reputation struct {
+	JobMatched               *bool  `json:"job_matched"`
+	JobCompletedNoValidation *bool  `json:"job_completed_no_validation"`
+	ValidationLost           *bool  `json:"validation_lost"`
+	RuntimeMillis            *int64 `json:"runtime_millis"`
+	ModuleID                 string `json:"module_id"`
+	JobFailed                *bool  `json:"job_failed"`
+}
+
+// The reputation builder constructs reputation from
+// reputation events. For now, it does not expose runtime
+// millis or module ID.
+type ReputationBuilder struct {
+	reputation Reputation
+}
+
+func NewReputationBuilder() *ReputationBuilder {
+	return &ReputationBuilder{}
+}
+
+func (b *ReputationBuilder) WithJobMatched(val bool) *ReputationBuilder {
+	b.reputation.JobMatched = &val
+	return b
+}
+
+func (b *ReputationBuilder) WithJobCompletedNoValidation(val bool) *ReputationBuilder {
+	b.reputation.JobCompletedNoValidation = &val
+	return b
+}
+
+func (b *ReputationBuilder) WithValidationLost(val bool) *ReputationBuilder {
+	b.reputation.ValidationLost = &val
+	return b
+}
+
+func (b *ReputationBuilder) WithJobFailed(val bool) *ReputationBuilder {
+	b.reputation.JobFailed = &val
+	return b
+}
+
+func (b *ReputationBuilder) Build() Reputation {
+	return b.reputation
+}
+
+// Stats API implementation
+
+func (stat *HTTPStats) PostReputation(address string, reputation Reputation) error {
+	path := fmt.Sprintf("/resource-provider/%s/reputation", address)
+	_, err := http.PostRequest[Reputation, Reputation](stat.ClientOptions, path, reputation)
+	if err != nil {
+		return fmt.Errorf("failed to post reputation: %s", err)
+	}
+
+	return nil
+}
+
+// Noop implementation
+
+func (stat *NoopStats) PostReputation(address string, reputation Reputation) error {
+	return nil
+}

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -1,5 +1,12 @@
 package stats
 
+import (
+	"github.com/lilypad-tech/lilypad/pkg/http"
+	"github.com/lilypad-tech/lilypad/pkg/system"
+
+	"github.com/lilypad-tech/lilypad/pkg/web3"
+)
+
 type StatsOptions struct {
 	Enabled bool
 	URL     string
@@ -7,17 +14,24 @@ type StatsOptions struct {
 
 type Stats interface{}
 
-func NewStats(options StatsOptions) (Stats, error) {
+func NewStats(service system.Service, options StatsOptions, web3Options web3.Web3Options, web3SDK *web3.Web3SDK) (Stats, error) {
 	if !options.Enabled {
 		return &NoopStats{}, nil
 	}
-	return &HTTPStats{URL: options.URL}, nil
+
+	return &HTTPStats{
+		ClientOptions: http.ClientOptions{
+			URL:           options.URL,
+			PrivateKey:    web3Options.PrivateKey,
+			Type:          string(service),
+			PublicAddress: web3SDK.GetAddress().String(),
+		}}, nil
 }
 
 // Stats API implementation
 
 type HTTPStats struct {
-	URL string
+	ClientOptions http.ClientOptions
 }
 
 // Noop implementation

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -1,9 +1,10 @@
 package stats
 
 import (
+	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
+	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
-
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 )
 
@@ -12,7 +13,9 @@ type StatsOptions struct {
 	URL     string
 }
 
-type Stats interface{}
+type Stats interface {
+	PostJobRun(store store.SolverStore, deal *data.DealContainer) error
+}
 
 func NewStats(service system.Service, options StatsOptions, web3Options web3.Web3Options, web3SDK *web3.Web3SDK) (Stats, error) {
 	if !options.Enabled {

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -3,7 +3,6 @@ package stats
 import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
-	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 )
@@ -14,7 +13,7 @@ type StatsOptions struct {
 }
 
 type Stats interface {
-	PostJobRun(store store.SolverStore, deal *data.DealContainer) error
+	PostJobRun(deal *data.DealContainer) error
 	PostReputation(address string, reputation Reputation) error
 }
 

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -4,3 +4,22 @@ type StatsOptions struct {
 	Enabled bool
 	URL     string
 }
+
+type Stats interface{}
+
+func NewStats(options StatsOptions) (Stats, error) {
+	if !options.Enabled {
+		return &NoopStats{}, nil
+	}
+	return &HTTPStats{URL: options.URL}, nil
+}
+
+// Stats API implementation
+
+type HTTPStats struct {
+	URL string
+}
+
+// Noop implementation
+
+type NoopStats struct{}

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -15,6 +15,7 @@ type StatsOptions struct {
 
 type Stats interface {
 	PostJobRun(store store.SolverStore, deal *data.DealContainer) error
+	PostReputation(address string, reputation Reputation) error
 }
 
 func NewStats(service system.Service, options StatsOptions, web3Options web3.Web3Options, web3SDK *web3.Web3SDK) (Stats, error) {

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -1,0 +1,6 @@
+package stats
+
+type StatsOptions struct {
+	Enabled bool
+	URL     string
+}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add solver `stats` package for reporting stats
  - [x] Add `stats` options
  - [x] Add `HTTPStats` implementation
  - [x] Add `NoopStats` implementation
- [x] Post job runs with job run timing to stats API
  - [x] Add `GetShortcut` helper to construct module identifier string
- [x] Post job completed (no validation) stat to stats API 

This pull request adds our initial stats reporting implementation to the solver. We start with reporting job runs with timing and jobs completed (no validation) to the stats API.

We have also updated the `downloadFiles` and `jobOfferDownloadFiles` handlers to improve error handling.

### Task/Issue reference

Closes: #506

### Test plan

Start the base services and the stats API. The stats API can re-use the postgres database from base services, so starting it should only require:

```sh
go run .
```

Start the solver enabling the stats API and providing the local stats URL:

```sh
./stack solver --enable-stats true --stats-url http://localhost:8080
```

Start the resource provider and run a job. Wait for the job to complete, then connect to the database. For example, using `psql`:

```bash
docker exec -it postgres psql -U postgres -d stats_api
```

Check the `job_runs` and `reputations` tables for records reflecting the job run:

```sql
select * from job_runs;
select * from reputations;
```

The `reputations` table should have a record with a `true` value in the `job_completed_no_validation` column.

### Details

**`stats` package**

The new stats package includes `HTTPStats` and `NoopStats` implementations. The `HTTPStats` implementation posts to the stats API. The `NoopStats` implementation is used when stats are disabled.

`HTTPStats` adds address and signature headers for authentication when reporting to the stats API.

**Reporting Job runs**

The `stats` package reports job runs including the following:

https://github.com/Lilypad-Tech/lilypad/blob/e303af4ab4df06df0490734d00b8aeb1440a8e11/pkg/solver/stats/jobrun.go#L15-L24

A job run starts when a job offer is created and ends when the job creator finishes downloading the job outputs. We only time successful runs in this pull request.

We rely on the `CreatedAt` field in the job offer as the starting point for a job. To avoid inaccurate reports, the solver only accepts job offers with recent creation times (see #523).

**Reporting reputation**

The `stats` reputation implementation includes a builder to collect multiple reputation stats before reporting. This pull request only reports jobs completed without validation, but in the future we will collect multiple reputation stats and report them in bulk where possible.

**Stats configs**

We have new `ENABLE_STATS` and `STATS_URL` configs. When `ENABLE_STATS` is `true`, `STATS_URL` must be set.

Enable stats with an environment variable of CLI option:

```
ENABLE_STATS=true ./stack solver
./stack solver --enable-stats true
```

Set the Stats API URL with an environment variable of CLI option:

```
STATS_URL=http://localhost:8080 ./stack solver
./stack solver --stats-url http://localhost:8080
```

**Download file updates**

We have also updated the `downloadFiles` and `jobOfferDownloadFiles` handlers to use our `http.GetHandler` middleware, which encodes JSON errors before sending them to the user. 

This change required us to return a `EmptyResponse` in success cases. The empty response should be ignored by downloaders because they are interested in the file download stream.

### Related issues or PRs

Epic: https://github.com/Lilypad-Tech/internal/issues/348
