### PR TITLE
feat: Add lilynext flag

### DIFF
--- a/cmd/lilypad/jobcreator.go
+++ b/cmd/lilypad/jobcreator.go
@@ -20,11 +20,12 @@ func newJobCreatorCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			network, _ := cmd.Flags().GetString("network")
+			lilynext, _ := cmd.Flags().GetBool("lilynext")
 			options, err := optionsfactory.ProcessOnChainJobCreatorOptions(options, args, network)
 			if err != nil {
 				return err
 			}
-			return runJobCreator(cmd, options, network)
+			return runJobCreator(cmd, options, network, lilynext)
 		},
 	}
 
@@ -33,9 +34,13 @@ func newJobCreatorCmd() *cobra.Command {
 	return solverCmd
 }
 
-func runJobCreator(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network string) error {
+func runJobCreator(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network string, lilynext bool) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
+
+	if lilynext {
+		log.Info().Msg("🍃 Running the new lilypad protocol")
+	}
 
 	telemetry, err := configureTelemetry(commandCtx.Ctx, system.JobCreatorService, network, options.Telemetry, nil, options.Web3)
 	if err != nil {

--- a/cmd/lilypad/resource-provider.go
+++ b/cmd/lilypad/resource-provider.go
@@ -20,13 +20,14 @@ func newResourceProviderCmd() *cobra.Command {
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			network, _ := cmd.Flags().GetString("network")
+			lilynext, _ := cmd.Flags().GetBool("lilynext")
 			options, err := optionsfactory.ProcessResourceProviderOptions(options, network)
 			if err != nil {
 				return err
 			}
 			cmd.SilenceUsage = true
 
-			return runResourceProvider(cmd, options, network)
+			return runResourceProvider(cmd, options, network, lilynext)
 		},
 	}
 
@@ -35,9 +36,13 @@ func newResourceProviderCmd() *cobra.Command {
 	return resourceProviderCmd
 }
 
-func runResourceProvider(cmd *cobra.Command, options resourceprovider.ResourceProviderOptions, network string) error {
+func runResourceProvider(cmd *cobra.Command, options resourceprovider.ResourceProviderOptions, network string, lilynext bool) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
+
+	if lilynext {
+		log.Info().Msg("🍃 Running the new lilypad protocol")
+	}
 
 	telemetry, err := configureTelemetry(commandCtx.Ctx, system.ResourceProviderService, network, options.Telemetry, nil, options.Web3)
 	if err != nil {

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -24,7 +24,9 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	var network string
+	var lilynext bool
 	RootCmd.PersistentFlags().StringVarP(&network, "network", "n", "testnet", "Sets a target network configuration")
+	RootCmd.PersistentFlags().BoolVar(&lilynext, "lilynext", false, "Use the new Lilypad protocol")
 
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -29,13 +29,14 @@ func newRunCmd() *cobra.Command {
 		Example: "run cowsay:v0.0.1 -i Message=moo",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			network, _ := cmd.Flags().GetString("network")
+			lilynext, _ := cmd.Flags().GetBool("lilynext")
 			options, err := optionsfactory.ProcessJobCreatorOptions(options, args, network)
 			if err != nil {
 				return err
 			}
 			cmd.SilenceUsage = true
 
-			return runJob(cmd, options, network)
+			return runJob(cmd, options, network, lilynext)
 		},
 	}
 
@@ -44,7 +45,7 @@ func newRunCmd() *cobra.Command {
 	return runCmd
 }
 
-func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network string) error {
+func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network string, lilynext bool) error {
 	c := color.New(color.FgCyan).Add(color.Bold)
 	header := `
 ⠀⠀⠀⠀⠀⠀⣀⣤⣤⢠⣤⣀⠀⠀⠀⠀⠀
@@ -85,6 +86,10 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions, network st
 
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
+
+	if lilynext {
+		log.Info().Msg("🍃 Running the new lilypad protocol")
+	}
 
 	telemetry, err := configureTelemetry(commandCtx.Ctx, system.JobCreatorService, network, options.Telemetry, nil, options.Web3)
 	if err != nil {

--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -25,13 +25,14 @@ func newSolverCmd() *cobra.Command {
 		Example: "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			network, _ := cmd.Flags().GetString("network")
+			lilynext, _ := cmd.Flags().GetBool("lilynext")
 			options, err := optionsfactory.ProcessSolverOptions(options, network)
 			if err != nil {
 				return err
 			}
 			cmd.SilenceUsage = true
 
-			return runSolver(cmd, options, network)
+			return runSolver(cmd, options, network, lilynext)
 		},
 	}
 
@@ -40,9 +41,13 @@ func newSolverCmd() *cobra.Command {
 	return solverCmd
 }
 
-func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string) error {
+func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string, lilynext bool) error {
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
+
+	if lilynext {
+		log.Info().Msg("🍃 Running the new lilypad protocol")
+	}
 
 	telemetry, err := configureTelemetry(commandCtx.Ctx, system.SolverService, network, options.Telemetry, &options.Metrics, options.Web3)
 	if err != nil {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add a global `lilynext` flag
- [x] Extract the `lilynext` flag in the solver, resource provider, run, and job creator commands

This pull request adds a `lilynext` feature flag to the gate the new protocol while we implement and stabilize it. The flag is available globally and consumed by commands that may implement the new protocol.

### Test plan

Run the solver with the `lilynext` flag:

```
./stack solver --lilynext
```

The solver should log a line at startup like:

```
2025-03-03T11:09:18-08:00 INF cmd/lilypad/solver.go:35 > 🍃 Running the new lilypad protocol
```

Running the solver without the `lilynext` flag should not log this line.

The same should hold true for the resource provider, run command, and job creator proxy.

### Details

We will need make the feature flag available throughout our code, wherever we implement new protocol.

Although we do not actively support the onchain job creator, we pass the flag to it because it shares functionality with the run command, so it may need it.

### Related issues or PRs

Epic: https://github.com/Lilypad-Tech/internal/issues/407
