### PR TITLE
feat: Add contextual logger

### DIFF
--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -45,10 +45,6 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string,
 	commandCtx := system.NewCommandContext(cmd)
 	defer commandCtx.Cleanup()
 
-	if lilynext {
-		log.Info().Msg("🍃 Running the new lilypad protocol")
-	}
-
 	telemetry, err := configureTelemetry(commandCtx.Ctx, system.SolverService, network, options.Telemetry, &options.Metrics, options.Web3)
 	if err != nil {
 		log.Warn().Msgf("failed to setup opentelemetry: %s", err)
@@ -56,6 +52,11 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string,
 	commandCtx.Cm.RegisterCallbackWithContext(telemetry.Shutdown)
 	tracer := telemetry.TracerProvider.Tracer(system.GetOTelServiceName(system.SolverService))
 	meter := telemetry.MeterProvider.Meter(system.GetOTelServiceName(system.SolverService))
+	log := system.GetLogger(system.SolverService)
+
+	if lilynext {
+		log.Info().Msg("🍃 Running the new lilypad protocol")
+	}
 
 	unregisterMetrics, err := system.NewMetrics(meter)
 	if err != nil {

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/web3"
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/mediation"
 	"github.com/lilypad-tech/lilypad/pkg/web3/bindings/storage"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -51,7 +51,7 @@ type SolverController struct {
 	loop            *system.ControlLoop
 	solverEventSubs []func(SolverEvent)
 	options         SolverOptions
-	log             *system.ServiceLogger
+	log             *zerolog.Logger
 	tracer          trace.Tracer
 	meter           metric.Meter
 }
@@ -75,7 +75,7 @@ func NewSolverController(
 		web3Events: web3.NewEventChannels(),
 		store:      store,
 		options:    options,
-		log:        system.NewServiceLogger(system.SolverService),
+		log:        system.GetLogger(system.SolverService),
 		tracer:     tracer,
 		meter:      meter,
 	}
@@ -92,7 +92,7 @@ func (controller *SolverController) Start(ctx context.Context, cm *system.Cleanu
 	}
 
 	// activate the web3 event listeners
-	log.Debug().Msgf("controller.web3Events.Start")
+	controller.log.Debug().Msgf("controller.web3Events.Start")
 	err = controller.web3Events.Start(ctx, cm, controller.web3SDK)
 	if err != nil {
 		errorChan <- err
@@ -101,7 +101,7 @@ func (controller *SolverController) Start(ctx context.Context, cm *system.Cleanu
 
 	// make sure we are registered as a solver
 	// so that users can lookup our URL
-	log.Debug().Msgf("controller.registerAsSolver")
+	controller.log.Debug().Msgf("controller.registerAsSolver")
 	err = controller.registerAsSolver()
 	if err != nil {
 		errorChan <- err
@@ -120,7 +120,7 @@ func (controller *SolverController) Start(ctx context.Context, cm *system.Cleanu
 			return err
 		},
 	)
-	log.Debug().Msgf("controller.loop.Start")
+	controller.log.Debug().Msgf("controller.loop.Start")
 	err = controller.loop.Start(true)
 	if err != nil {
 		errorChan <- err
@@ -151,10 +151,10 @@ func (controller *SolverController) subscribeToWeb3() error {
 	controller.web3Events.Storage.SubscribeDealStateChange(func(ev storage.StorageDealStateChange) {
 		_, err := controller.updateDealState(ev.DealId, ev.State)
 		if err != nil {
-			controller.log.Error("error updating deal state", err)
+			controller.log.Error().Err(err).Msg("error updating deal state")
 			return
 		}
-		controller.log.Info("StorageDealStateChange", data.GetAgreementStateString(ev.State))
+		controller.log.Info().Str("StorageDealStateChange", data.GetAgreementStateString(ev.State)).Msg("")
 		system.DumpObjectDebug(ev)
 		// update the store with the state change
 		controller.loop.Trigger()
@@ -162,11 +162,11 @@ func (controller *SolverController) subscribeToWeb3() error {
 
 	// update the mediator
 	controller.web3Events.Mediation.SubscribeMediationRequested(func(ev mediation.MediationMediationRequested) {
-		controller.log.Info("MediationMediationRequested", "")
+		controller.log.Info().Msg("MediationMediationRequested")
 		system.DumpObjectDebug(ev)
 		_, err := controller.updateDealMediator(ev.DealId, ev.Mediator.String())
 		if err != nil {
-			controller.log.Error("error updating deal state", err)
+			controller.log.Error().Err(err).Msg("error updating deal state")
 			return
 		}
 
@@ -217,17 +217,22 @@ func (controller *SolverController) registerAsSolver() error {
 		return err
 	}
 
-	log.Debug().Msgf("GetUser with selfAddress: %s", selfAddress.String())
+	controller.log.Debug().Msgf("GetUser with selfAddress: %s", selfAddress.String())
 	selfUser, err := controller.web3SDK.GetUser(selfAddress)
 	if err != nil {
 		return err
 	}
 
 	// TODO: check the other props and call update if they have changed
-	log.Debug().Msgf("selfUser.Url: %s", selfUser.Url)
-	log.Debug().Msgf("controller.options.Server.URL: %s", controller.options.Server.URL)
+	controller.log.Debug().Msgf("selfUser.Url: %s", selfUser.Url)
+	controller.log.Debug().Msgf("controller.options.Server.URL: %s", controller.options.Server.URL)
 	if selfUser.Url != controller.options.Server.URL {
-		controller.log.Info("url change", fmt.Sprintf("solver will be updated because URL has changed: %s %s != %s", selfAddress.String(), selfUser.Url, controller.options.Server.URL))
+		controller.log.Info().
+			Str("address", selfAddress.String()).
+			Str("oldURL", selfUser.Url).
+			Str("newURL", controller.options.Server.URL).
+			Msg("solver will be updated because URL has changed")
+
 		err = controller.web3SDK.UpdateUser(
 			"",
 			controller.options.Server.URL,
@@ -237,7 +242,10 @@ func (controller *SolverController) registerAsSolver() error {
 			return err
 		}
 	} else {
-		controller.log.Info("url same", fmt.Sprintf("solver url already correct: %s %s", selfAddress.String(), controller.options.Server.URL))
+		controller.log.Info().
+			Str("address", selfAddress.String()).
+			Str("url", controller.options.Server.URL).
+			Msg("solver url already correct")
 	}
 
 	existingSolvers, err := controller.web3SDK.GetSolverAddresses()
@@ -247,13 +255,13 @@ func (controller *SolverController) registerAsSolver() error {
 	foundSolver := false
 	for _, existingSolver := range existingSolvers {
 		if existingSolver.String() == selfAddress.String() {
-			controller.log.Info("solver exists", selfAddress.String())
+			controller.log.Info().Str("address", selfAddress.String()).Msg("solver exists")
 			foundSolver = true
 			break
 		}
 	}
 	if !foundSolver {
-		controller.log.Info("solver registering", "")
+		controller.log.Info().Msg("solver registering")
 		// add the solver to the storage contract
 		err = controller.web3SDK.AddUserToList(
 			solverType,
@@ -261,7 +269,7 @@ func (controller *SolverController) registerAsSolver() error {
 		if err != nil {
 			return err
 		}
-		controller.log.Info("solver registered", selfAddress.String())
+		controller.log.Info().Str("address", selfAddress.String()).Msg("solver registered")
 	}
 	return nil
 }
@@ -346,7 +354,7 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 		Active: true,
 	})
 	if err != nil {
-		controller.log.Error("get job offers failed", err)
+		controller.log.Error().Err(err).Msg("get job offers failed")
 		span.SetStatus(codes.Error, "get job offers failed")
 		span.RecordError(err)
 		return err
@@ -365,7 +373,7 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 				// Cancel expired job offers
 				_, err := controller.updateJobOfferState(jobOffer.ID, jobOffer.DealID, data.GetAgreementStateIndex("JobTimedOut"))
 				if err != nil {
-					controller.log.Error("update expired job offer state failed", err)
+					controller.log.Error().Err(err).Msg("update expired job offer state failed")
 					span.SetStatus(codes.Error, "update expired job offer state failed")
 					span.RecordError(err)
 				}
@@ -373,7 +381,7 @@ func (controller *SolverController) cancelExpiredJobs(ctx context.Context) error
 				// Cancel expired job offers, resource offers, and deals
 				_, err := controller.updateDealState(jobOffer.DealID, data.GetAgreementStateIndex("JobTimedOut"))
 				if err != nil {
-					controller.log.Error("update expired deal state failed", err)
+					controller.log.Error().Err(err).Msg("update expired deal state failed")
 					span.SetStatus(codes.Error, "update expired deal state failed")
 					span.RecordError(err)
 				}
@@ -413,7 +421,7 @@ func (controller *SolverController) addJobOffer(jobOffer data.JobOffer) (*data.J
 	}
 	jobOffer.ID = id
 
-	controller.log.Info("add job offer", jobOffer)
+	controller.log.Info().Any("jobOffer", jobOffer).Msg("add job offer")
 
 	ret, err := controller.store.AddJobOffer(data.GetJobOfferContainer(jobOffer))
 	if err != nil {
@@ -443,8 +451,11 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 
 	// If the balance is less than the required balance, don't add the resource offer
 	if balance.Cmp(requiredBalanceWei) < 0 {
-		err := fmt.Errorf("address %s doesn't have enough ETH balance. The required balance is %s but current balance is %s", resourceOffer.ResourceProvider, requiredBalanceWei, balance)
-		controller.log.Error("ETH balance check failed", err)
+		controller.log.Error().Err(err).
+			Str("addresss", resourceOffer.ResourceProvider).
+			Str("balance", balance.String()).
+			Str("requiredBalance", requiredBalanceWei.String()).
+			Msg("resource provider does not have enough ETH to post offer")
 		return nil, nil
 	}
 
@@ -452,17 +463,19 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 	requiredBalanceLp := web3.EtherToWei(float64(resourceOffer.DefaultPricing.InstructionPrice)) // based on the required LP balance for a job
 	balanceLp, err := controller.web3SDK.GetLPBalance(resourceOffer.ResourceProvider)
 	if err != nil {
-		err := fmt.Errorf("failed to retrieve LP balance for resource provider: %v", err)
-		controller.log.Error("LP Balance error", err)
+		controller.log.Error().Err(err).Msg("failed to retrieve LP balance for resource provider")
 		return nil, nil
 	}
 	if balanceLp.Cmp(requiredBalanceLp) < 0 {
-		err := fmt.Errorf("address %s doesn't have enough LP balance. The required balance is %s but current balance is %s", resourceOffer.ResourceProvider, requiredBalanceLp, balanceLp)
-		controller.log.Error("LP balance check failed", err)
+		controller.log.Error().Err(err).
+			Str("addresss", resourceOffer.ResourceProvider).
+			Str("balance", balanceLp.String()).
+			Str("requiredBalance", requiredBalanceLp.String()).
+			Msg("resource provider does not have enough LP to post offer")
 		return nil, nil
 	}
 
-	controller.log.Info("add resource offer", resourceOffer)
+	controller.log.Info().Any("resourceOffer", resourceOffer).Msg("add resource offer")
 
 	metricsDashboard.TrackNodeInfo(resourceOffer)
 
@@ -480,7 +493,7 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 
 // Remove resource offers in an unmatched DealNegotiating[0] state
 func (controller *SolverController) removeUnmatchedResourceOffers(resourceProviderID string) error {
-	controller.log.Info("remove resource offer", resourceProviderID)
+	controller.log.Info().Str("address", resourceProviderID).Msg("remove unmatched resource offers")
 	resourceOffers, err := controller.store.GetResourceOffers(store.GetResourceOffersQuery{
 		ResourceProvider: resourceProviderID,
 	})
@@ -492,8 +505,10 @@ func (controller *SolverController) removeUnmatchedResourceOffers(resourceProvid
 		if offer.State == 0 {
 			err = controller.store.RemoveResourceOffer(offer.ID)
 			if err != nil {
-				controller.log.Error("remove resource offer failed",
-					fmt.Errorf("resource provider: %s, offer ID: %s, error: %s", resourceProviderID, offer.ID, err))
+				controller.log.Error().Err(err).
+					Str("address", resourceProviderID).
+					Str("cid", offer.ID).
+					Msg("remove resource offer failed")
 			}
 		}
 	}
@@ -520,7 +535,7 @@ func (controller *SolverController) addDeal(ctx context.Context, deal data.Deal)
 	span.SetAttributes(attribute.String("deal.id", deal.ID))
 	span.AddEvent("data.get_deal_id.done")
 
-	controller.log.Info("add deal", deal)
+	controller.log.Info().Any("deal", deal).Msg("add deal")
 
 	//creates deal container and sets state to agreed
 	dealContainer := data.GetDealContainer(deal)
@@ -575,7 +590,7 @@ func (controller *SolverController) addDeal(ctx context.Context, deal data.Deal)
 *
 */
 func (controller *SolverController) updateJobOfferState(id string, dealID string, state uint8) (*data.JobOfferContainer, error) {
-	controller.log.Info("update job offer", fmt.Sprintf("%s %s", id, data.GetAgreementStateString(state)))
+	controller.log.Info().Str("cid", id).Str("state", data.GetAgreementStateString(state)).Msg("update job offer")
 
 	ret, err := controller.store.UpdateJobOfferState(id, dealID, state)
 	if err != nil {
@@ -589,7 +604,7 @@ func (controller *SolverController) updateJobOfferState(id string, dealID string
 }
 
 func (controller *SolverController) updateResourceOfferState(id string, dealID string, state uint8) (*data.ResourceOfferContainer, error) {
-	controller.log.Info("update resource offer", fmt.Sprintf("%s %s", id, data.GetAgreementStateString(state)))
+	controller.log.Info().Str("cid", id).Str("state", data.GetAgreementStateString(state)).Msg("update resource offer")
 
 	ret, err := controller.store.UpdateResourceOfferState(id, dealID, state)
 	if err != nil {
@@ -604,7 +619,7 @@ func (controller *SolverController) updateResourceOfferState(id string, dealID s
 
 // this will also update the job and resource offer states
 func (controller *SolverController) updateDealState(id string, state uint8) (*data.DealContainer, error) {
-	controller.log.Info("update deal", fmt.Sprintf("%s %s", id, data.GetAgreementStateString(state)))
+	controller.log.Info().Str("cid", id).Str("state", data.GetAgreementStateString(state)).Msg("update deal")
 
 	dealContainer, err := controller.store.UpdateDealState(id, state)
 	if err != nil {
@@ -628,7 +643,7 @@ func (controller *SolverController) updateDealState(id string, state uint8) (*da
 
 // this will also update the job and resource offer states
 func (controller *SolverController) updateDealMediator(id string, mediator string) (*data.DealContainer, error) {
-	controller.log.Info("update mediator", fmt.Sprintf("%s %s", id, mediator))
+	controller.log.Info().Str("cid", id).Str("address", mediator).Msg("update deal mediator")
 	dealContainer, err := controller.store.UpdateDealMediator(id, mediator)
 	if err != nil {
 		return nil, err
@@ -652,7 +667,7 @@ func (controller *SolverController) updateDealMediator(id string, mediator strin
 *
 */
 func (controller *SolverController) updateDealTransactionsResourceProvider(id string, payload data.DealTransactionsResourceProvider) (*data.DealContainer, error) {
-	controller.log.Info("update resource provider txs", payload)
+	controller.log.Info().Any("payload", payload).Msg("update resource provider txs")
 	dealContainer, err := controller.store.UpdateDealTransactionsResourceProvider(id, payload)
 	if err != nil {
 		return nil, err
@@ -665,7 +680,7 @@ func (controller *SolverController) updateDealTransactionsResourceProvider(id st
 }
 
 func (controller *SolverController) updateDealTransactionsJobCreator(id string, payload data.DealTransactionsJobCreator) (*data.DealContainer, error) {
-	controller.log.Info("update job creator txs", payload)
+	controller.log.Info().Any("payload", payload).Msg("update job creator txs")
 	dealContainer, err := controller.store.UpdateDealTransactionsJobCreator(id, payload)
 	if err != nil {
 		return nil, err
@@ -681,7 +696,7 @@ func (controller *SolverController) updateDealTransactionsJobCreator(id string, 
 }
 
 func (controller *SolverController) updateDealTransactionsMediator(id string, payload data.DealTransactionsMediator) (*data.DealContainer, error) {
-	controller.log.Info("update mediator txs", payload)
+	controller.log.Info().Any("payload", payload).Msg("update mediator txs")
 	dealContainer, err := controller.store.UpdateDealTransactionsMediator(id, payload)
 	if err != nil {
 		return nil, err

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -299,7 +299,7 @@ func (controller *SolverController) solve(ctx context.Context) error {
 	}
 
 	// Match job offers with resource offers to make deals
-	deals, err := matcher.GetMatchingDeals(ctx, controller.store, controller.updateJobOfferState, controller.log, controller.tracer, controller.meter)
+	deals, err := matcher.GetMatchingDeals(ctx, controller.store, controller.updateJobOfferState, controller.tracer, controller.meter)
 	if err != nil {
 		span.SetStatus(codes.Error, "get matching deals failed")
 		span.RecordError(err)

--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -421,7 +421,10 @@ func (controller *SolverController) addJobOffer(jobOffer data.JobOffer) (*data.J
 	}
 	jobOffer.ID = id
 
-	controller.log.Info().Any("jobOffer", jobOffer).Msg("add job offer")
+	controller.log.Info().Str("cid", jobOffer.ID).
+		Str("address", jobOffer.JobCreator).
+		Any("jobOffer", jobOffer).
+		Msg("add job offer")
 
 	ret, err := controller.store.AddJobOffer(data.GetJobOfferContainer(jobOffer))
 	if err != nil {
@@ -475,7 +478,10 @@ func (controller *SolverController) addResourceOffer(resourceOffer data.Resource
 		return nil, nil
 	}
 
-	controller.log.Info().Any("resourceOffer", resourceOffer).Msg("add resource offer")
+	controller.log.Info().Str("cid", resourceOffer.ID).
+		Str("address", resourceOffer.ResourceProvider).
+		Any("resourceOffer", resourceOffer).
+		Msg("add resource offer")
 
 	metricsDashboard.TrackNodeInfo(resourceOffer)
 
@@ -535,7 +541,11 @@ func (controller *SolverController) addDeal(ctx context.Context, deal data.Deal)
 	span.SetAttributes(attribute.String("deal.id", deal.ID))
 	span.AddEvent("data.get_deal_id.done")
 
-	controller.log.Info().Any("deal", deal).Msg("add deal")
+	controller.log.Info().Str("cid", deal.ID).
+		Str("resourceProvider", deal.Members.ResourceProvider).
+		Str("jobCreator", deal.Members.JobCreator).
+		Any("deal", deal).
+		Msg("add deal")
 
 	//creates deal container and sets state to agreed
 	dealContainer := data.GetDealContainer(deal)

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -379,7 +379,7 @@ func getLargestVRAM(gpus []data.GPUSpec) int {
 	return largestVRAM
 }
 
-func logMatch(result matchResult) {
+func logMatch(result matchResult, log *zerolog.Logger) {
 	switch r := result.(type) {
 	case offersMatched:
 		log.Trace().

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -67,7 +67,7 @@ func NewSolverServer(
 *
 *
 */
-func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system.CleanupManager, tracerProvider *trace.TracerProvider) error {
+func (server *solverServer) ListenAndServe(ctx context.Context, cm *system.CleanupManager, tracerProvider *trace.TracerProvider) error {
 	router := mux.NewRouter()
 
 	subrouter := router.PathPrefix(http.API_SUB_PATH).Subrouter()
@@ -76,39 +76,39 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 	subrouter.Use(otelmux.Middleware("solver", otelmux.WithTracerProvider(tracerProvider)))
 
 	subrouter.Use(httprate.Limit(
-		solverServer.options.RateLimiter.RequestLimit,
-		time.Duration(solverServer.options.RateLimiter.WindowLength)*time.Second,
+		server.options.RateLimiter.RequestLimit,
+		time.Duration(server.options.RateLimiter.WindowLength)*time.Second,
 		httprate.WithKeyFuncs(httprate.KeyByRealIP, httprate.KeyByEndpoint),
 	))
 
-	subrouter.HandleFunc("/job_offers", http.GetHandler(solverServer.getJobOffers)).Methods("GET")
-	subrouter.HandleFunc("/job_offers", http.PostHandler(solverServer.addJobOffer)).Methods("POST")
+	subrouter.HandleFunc("/job_offers", http.GetHandler(server.getJobOffers)).Methods("GET")
+	subrouter.HandleFunc("/job_offers", http.PostHandler(server.addJobOffer)).Methods("POST")
 
-	subrouter.HandleFunc("/job_offers/{id}", http.GetHandler(solverServer.getJobOffer)).Methods("GET")
-	subrouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(solverServer.jobOfferDownloadFiles)).Methods("GET")
+	subrouter.HandleFunc("/job_offers/{id}", http.GetHandler(server.getJobOffer)).Methods("GET")
+	subrouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(server.jobOfferDownloadFiles)).Methods("GET")
 
-	subrouter.HandleFunc("/resource_offers", http.GetHandler(solverServer.getResourceOffers)).Methods("GET")
-	subrouter.HandleFunc("/resource_offers", http.PostHandler(solverServer.addResourceOffer)).Methods("POST")
+	subrouter.HandleFunc("/resource_offers", http.GetHandler(server.getResourceOffers)).Methods("GET")
+	subrouter.HandleFunc("/resource_offers", http.PostHandler(server.addResourceOffer)).Methods("POST")
 
-	subrouter.HandleFunc("/deals", http.GetHandler(solverServer.getDeals)).Methods("GET")
-	subrouter.HandleFunc("/deals/{id}", http.GetHandler(solverServer.getDeal)).Methods("GET")
+	subrouter.HandleFunc("/deals", http.GetHandler(server.getDeals)).Methods("GET")
+	subrouter.HandleFunc("/deals/{id}", http.GetHandler(server.getDeal)).Methods("GET")
 
-	subrouter.HandleFunc("/deals/{id}/files", http.GetHandler(solverServer.downloadFiles)).Methods("GET")
-	subrouter.HandleFunc("/deals/{id}/files", solverServer.uploadFiles).Methods("POST")
+	subrouter.HandleFunc("/deals/{id}/files", http.GetHandler(server.downloadFiles)).Methods("GET")
+	subrouter.HandleFunc("/deals/{id}/files", server.uploadFiles).Methods("POST")
 
-	subrouter.HandleFunc("/deals/{id}/result", http.GetHandler(solverServer.getResult)).Methods("GET")
-	subrouter.HandleFunc("/deals/{id}/result", http.PostHandler(solverServer.addResult)).Methods("POST")
+	subrouter.HandleFunc("/deals/{id}/result", http.GetHandler(server.getResult)).Methods("GET")
+	subrouter.HandleFunc("/deals/{id}/result", http.PostHandler(server.addResult)).Methods("POST")
 
-	subrouter.HandleFunc("/deals/{id}/txs/resource_provider", http.PostHandler(solverServer.updateTransactionsResourceProvider)).Methods("POST")
-	subrouter.HandleFunc("/deals/{id}/txs/job_creator", http.PostHandler(solverServer.updateTransactionsJobCreator)).Methods("POST")
-	subrouter.HandleFunc("/deals/{id}/txs/mediator", http.PostHandler(solverServer.updateTransactionsMediator)).Methods("POST")
+	subrouter.HandleFunc("/deals/{id}/txs/resource_provider", http.PostHandler(server.updateTransactionsResourceProvider)).Methods("POST")
+	subrouter.HandleFunc("/deals/{id}/txs/job_creator", http.PostHandler(server.updateTransactionsJobCreator)).Methods("POST")
+	subrouter.HandleFunc("/deals/{id}/txs/mediator", http.PostHandler(server.updateTransactionsMediator)).Methods("POST")
 
-	subrouter.HandleFunc("/validation_token", http.GetHandler(solverServer.getValidationToken)).Methods("GET")
+	subrouter.HandleFunc("/validation_token", http.GetHandler(server.getValidationToken)).Methods("GET")
 
 	//anura subrouter
 	anuraMiddleware := func(next corehttp.Handler) corehttp.Handler {
 		return corehttp.HandlerFunc(func(w corehttp.ResponseWriter, r *corehttp.Request) {
-			_, err := http.CheckAnuraSignature(r, solverServer.options.AccessControl.AnuraAddresses)
+			_, err := http.CheckAnuraSignature(r, server.options.AccessControl.AnuraAddresses)
 			if err != nil {
 				corehttp.Error(w, "Unauthorized", corehttp.StatusUnauthorized)
 				return
@@ -122,18 +122,18 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 	anurarouter.Use(otelmux.Middleware("solver", otelmux.WithTracerProvider(tracerProvider)))
 	anurarouter.Use(anuraMiddleware)
 
-	anurarouter.HandleFunc("/job_offers", http.PostHandler(solverServer.addJobOffer)).Methods("POST")
-	anurarouter.HandleFunc("/job_offers", http.GetHandler(solverServer.getJobOffers)).Methods("GET")
-	anurarouter.HandleFunc("/job_offers/{id}", http.GetHandler(solverServer.getJobOffer)).Methods("GET")
-	anurarouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(solverServer.jobOfferDownloadFiles)).Methods("GET")
+	anurarouter.HandleFunc("/job_offers", http.PostHandler(server.addJobOffer)).Methods("POST")
+	anurarouter.HandleFunc("/job_offers", http.GetHandler(server.getJobOffers)).Methods("GET")
+	anurarouter.HandleFunc("/job_offers/{id}", http.GetHandler(server.getJobOffer)).Methods("GET")
+	anurarouter.HandleFunc("/job_offers/{id}/files", http.GetHandler(server.jobOfferDownloadFiles)).Methods("GET")
 
 	// this will fan out to all connected web socket connections
 	// we read all events coming from inside the solver controller
 	// and write them to anyone who is connected to us
 	websocketEventChannel := make(chan []byte)
 
-	log.Debug().Msgf("begin solverServer.controller.subscribeEvents")
-	solverServer.controller.subscribeEvents(func(ev SolverEvent) {
+	log.Debug().Msgf("begin server.controller.subscribeEvents")
+	server.controller.subscribeEvents(func(ev SolverEvent) {
 		evBytes, err := json.Marshal(ev)
 		if err != nil {
 			log.Error().Msgf("Error marshalling event: %s", err.Error())
@@ -146,12 +146,12 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 		http.WEBSOCKET_SUB_PATH,
 		websocketEventChannel,
 		ctx,
-		solverServer.connectCB,
-		solverServer.disconnectCB,
+		server.connectCB,
+		server.disconnectCB,
 	)
 
 	srv := &corehttp.Server{
-		Addr:              fmt.Sprintf("%s:%d", solverServer.options.Host, solverServer.options.Port),
+		Addr:              fmt.Sprintf("%s:%d", server.options.Host, server.options.Port),
 		WriteTimeout:      time.Minute * 15,
 		ReadTimeout:       time.Minute * 15,
 		ReadHeaderTimeout: time.Minute * 15,
@@ -185,7 +185,7 @@ func (solverServer *solverServer) ListenAndServe(ctx context.Context, cm *system
 }
 
 // WS connect events
-func (solverServer *solverServer) connectCB(connParams http.WSConnectionParams) {
+func (server *solverServer) connectCB(connParams http.WSConnectionParams) {
 	if connParams.Type == "ResourceProvider" {
 		metricsDashboard.TrackNodeConnectionEvent(metricsDashboard.NodeConnectionParams{
 			Event:       "Connect",
@@ -196,7 +196,7 @@ func (solverServer *solverServer) connectCB(connParams http.WSConnectionParams) 
 	}
 }
 
-func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParams) {
+func (server *solverServer) disconnectCB(connParams http.WSConnectionParams) {
 	if connParams.Type == "ResourceProvider" {
 		metricsDashboard.TrackNodeConnectionEvent(metricsDashboard.NodeConnectionParams{
 			Event:       "Disconnect",
@@ -204,7 +204,7 @@ func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParam
 			CountryCode: connParams.CountryCode,
 			IP:          connParams.IP,
 		})
-		solverServer.controller.removeUnmatchedResourceOffers(connParams.ID)
+		server.controller.removeUnmatchedResourceOffers(connParams.ID)
 	}
 }
 
@@ -219,7 +219,7 @@ func (solverServer *solverServer) disconnectCB(connParams http.WSConnectionParam
 *
 *
 */
-func (solverServer *solverServer) getJobOffers(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.JobOfferContainer, error) {
+func (server *solverServer) getJobOffers(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.JobOfferContainer, error) {
 	query := store.GetJobOffersQuery{}
 	// if there is a job_creator query param then assign it
 	if jobCreator := req.URL.Query().Get("job_creator"); jobCreator != "" {
@@ -239,10 +239,10 @@ func (solverServer *solverServer) getJobOffers(res corehttp.ResponseWriter, req 
 		}
 	}
 
-	return solverServer.store.GetJobOffers(query)
+	return server.store.GetJobOffers(query)
 }
 
-func (solverServer *solverServer) getResourceOffers(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.ResourceOfferContainer, error) {
+func (server *solverServer) getResourceOffers(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.ResourceOfferContainer, error) {
 	query := store.GetResourceOffersQuery{}
 	// if there is a job_creator query param then assign it
 	if resourceProvider := req.URL.Query().Get("resource_provider"); resourceProvider != "" {
@@ -254,10 +254,10 @@ func (solverServer *solverServer) getResourceOffers(res corehttp.ResponseWriter,
 	if notMatched := req.URL.Query().Get("not_matched"); notMatched == "true" {
 		query.NotMatched = true
 	}
-	return solverServer.store.GetResourceOffers(query)
+	return server.store.GetResourceOffers(query)
 }
 
-func (solverServer *solverServer) getDeals(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.DealContainer, error) {
+func (server *solverServer) getDeals(res corehttp.ResponseWriter, req *corehttp.Request) ([]data.DealContainer, error) {
 	query := store.GetDealsQuery{}
 	// if there is a job_creator query param then assign it
 	if jobCreator := req.URL.Query().Get("job_creator"); jobCreator != "" {
@@ -269,7 +269,7 @@ func (solverServer *solverServer) getDeals(res corehttp.ResponseWriter, req *cor
 	if state := req.URL.Query().Get("state"); state != "" {
 		query.State = state
 	}
-	return solverServer.store.GetDeals(query)
+	return server.store.GetDeals(query)
 }
 
 /*
@@ -284,20 +284,20 @@ func (solverServer *solverServer) getDeals(res corehttp.ResponseWriter, req *cor
 *
 */
 
-func (solverServer *solverServer) getJobOffer(res corehttp.ResponseWriter, req *corehttp.Request) (data.JobOfferContainer, error) {
+func (server *solverServer) getJobOffer(res corehttp.ResponseWriter, req *corehttp.Request) (data.JobOfferContainer, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	jobOffer, err := solverServer.store.GetJobOffer(id)
+	jobOffer, err := server.store.GetJobOffer(id)
 	if err != nil {
 		return data.JobOfferContainer{}, err
 	}
 	return *jobOffer, nil
 }
 
-func (solverServer *solverServer) getDeal(res corehttp.ResponseWriter, req *corehttp.Request) (data.DealContainer, error) {
+func (server *solverServer) getDeal(res corehttp.ResponseWriter, req *corehttp.Request) (data.DealContainer, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		return data.DealContainer{}, err
 	}
@@ -307,10 +307,10 @@ func (solverServer *solverServer) getDeal(res corehttp.ResponseWriter, req *core
 	return *deal, nil
 }
 
-func (solverServer *solverServer) getResult(res corehttp.ResponseWriter, req *corehttp.Request) (data.Result, error) {
+func (server *solverServer) getResult(res corehttp.ResponseWriter, req *corehttp.Request) (data.Result, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	result, err := solverServer.store.GetResult(id)
+	result, err := server.store.GetResult(id)
 	if err != nil {
 		return data.Result{}, err
 	}
@@ -331,7 +331,7 @@ func (solverServer *solverServer) getResult(res corehttp.ResponseWriter, req *co
 *
 *
 */
-func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.JobOfferContainer, error) {
+func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.JobOfferContainer, error) {
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("error checking signature")
@@ -343,7 +343,7 @@ func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res coreht
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
 
-	offerRecent := isTimestampRecent(jobOffer.CreatedAt, solverServer.options.AccessControl.OfferTimestampDiffSeconds*1000)
+	offerRecent := isTimestampRecent(jobOffer.CreatedAt, server.options.AccessControl.OfferTimestampDiffSeconds*1000)
 	if !offerRecent {
 		log.Debug().Msgf("Job offer from %s rejected because timestamp was not recent", jobOffer.JobCreator)
 		return nil, errors.New("job offer rejected because CreatedAt time is not recent, check your computer's time settings and network connection")
@@ -355,10 +355,10 @@ func (solverServer *solverServer) addJobOffer(jobOffer data.JobOffer, res coreht
 		return nil, err
 	}
 
-	return solverServer.controller.addJobOffer(jobOffer)
+	return server.controller.addJobOffer(jobOffer)
 }
 
-func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.ResourceOfferContainer, error) {
+func (server *solverServer) addResourceOffer(resourceOffer data.ResourceOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.ResourceOfferContainer, error) {
 	versionHeader, _ := http.GetVersionFromHeaders(req)
 	log.Debug().Msgf("resource provider adding offer with version header %s", versionHeader)
 
@@ -373,8 +373,8 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 	}
 
 	// Resource provider must be in allowlist when enabled
-	if solverServer.options.AccessControl.EnableResourceProviderAllowlist {
-		allowedProviders, err := solverServer.store.GetAllowedResourceProviders()
+	if server.options.AccessControl.EnableResourceProviderAllowlist {
+		allowedProviders, err := server.store.GetAllowedResourceProviders()
 		if err != nil {
 			log.Error().Err(err).Msgf("Unable to load resource provider allowlist: %s", err)
 			return nil, err
@@ -386,7 +386,7 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 		}
 	}
 
-	offerRecent := isTimestampRecent(resourceOffer.CreatedAt, solverServer.options.AccessControl.OfferTimestampDiffSeconds*1000)
+	offerRecent := isTimestampRecent(resourceOffer.CreatedAt, server.options.AccessControl.OfferTimestampDiffSeconds*1000)
 	if !offerRecent {
 		log.Debug().Msgf("Resource offer from %s rejected because timestamp was not recent", resourceOffer.ResourceProvider)
 		return nil, errors.New("resource offer rejected because CreatedAt time is not recent, check your computer's time settings and network connection")
@@ -397,13 +397,13 @@ func (solverServer *solverServer) addResourceOffer(resourceOffer data.ResourceOf
 		log.Error().Err(err).Msgf("Error checking resource offer")
 		return nil, err
 	}
-	return solverServer.controller.addResourceOffer(resourceOffer)
+	return server.controller.addResourceOffer(resourceOffer)
 }
 
-func (solverServer *solverServer) addResult(results data.Result, res corehttp.ResponseWriter, req *corehttp.Request) (*data.Result, error) {
+func (server *solverServer) addResult(results data.Result, res corehttp.ResponseWriter, req *corehttp.Request) (*data.Result, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading deal")
 		return nil, err
@@ -431,12 +431,12 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 	}
 	results.DealID = id
 
-	storedResult, err := solverServer.store.AddResult(results)
+	storedResult, err := server.store.AddResult(results)
 	if err != nil {
 		return nil, err
 	}
 
-	err = solverServer.updateJobStates(id, "ResultsSubmitted")
+	err = server.updateJobStates(id, "ResultsSubmitted")
 	if err != nil {
 		return nil, err
 	}
@@ -455,10 +455,10 @@ func (solverServer *solverServer) addResult(results data.Result, res corehttp.Re
 *
 *
 */
-func (solverServer *solverServer) updateTransactionsResourceProvider(payload data.DealTransactionsResourceProvider, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
+func (server *solverServer) updateTransactionsResourceProvider(payload data.DealTransactionsResourceProvider, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading deal")
 		return nil, err
@@ -476,13 +476,13 @@ func (solverServer *solverServer) updateTransactionsResourceProvider(payload dat
 	if signerAddress != deal.ResourceProvider {
 		return nil, fmt.Errorf("resource provider address does not match signer address")
 	}
-	return solverServer.controller.updateDealTransactionsResourceProvider(id, payload)
+	return server.controller.updateDealTransactionsResourceProvider(id, payload)
 }
 
-func (solverServer *solverServer) updateTransactionsJobCreator(payload data.DealTransactionsJobCreator, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
+func (server *solverServer) updateTransactionsJobCreator(payload data.DealTransactionsJobCreator, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading deal")
 		return nil, err
@@ -500,13 +500,13 @@ func (solverServer *solverServer) updateTransactionsJobCreator(payload data.Deal
 	if signerAddress != deal.JobCreator {
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
-	return solverServer.controller.updateDealTransactionsJobCreator(id, payload)
+	return server.controller.updateDealTransactionsJobCreator(id, payload)
 }
 
-func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTransactionsMediator, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
+func (server *solverServer) updateTransactionsMediator(payload data.DealTransactionsMediator, res corehttp.ResponseWriter, req *corehttp.Request) (*data.DealContainer, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading deal")
 		return nil, err
@@ -524,7 +524,7 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 	if signerAddress != deal.Mediator {
 		return nil, fmt.Errorf("job creator address does not match mediator address")
 	}
-	return solverServer.controller.updateDealTransactionsMediator(id, payload)
+	return server.controller.updateDealTransactionsMediator(id, payload)
 }
 
 /*
@@ -543,12 +543,12 @@ func (solverServer *solverServer) updateTransactionsMediator(payload data.DealTr
 // but the client expects a file stream and will ignore it.
 type EmptyResponse struct{}
 
-func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
+func (server *solverServer) downloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
 
 	// Get the deal
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		return EmptyResponse{}, &http.HTTPError{
 			Message:    "error loading deal",
@@ -578,9 +578,9 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 		}
 	}
 
-	if err := solverServer.handleFileDownload(GetDealsFilePath(id), res, func() {
-		solverServer.stats.PostJobRun(deal)
-		solverServer.stats.PostReputation(deal.ResourceProvider,
+	if err := server.handleFileDownload(GetDealsFilePath(id), res, func() {
+		server.stats.PostJobRun(deal)
+		server.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).
 				Build(),
@@ -592,7 +592,7 @@ func (solverServer *solverServer) downloadFiles(res corehttp.ResponseWriter, req
 	return EmptyResponse{}, nil
 }
 
-func (solverServer *solverServer) handleFileDownload(dirPath string, res corehttp.ResponseWriter, onCompletion func()) *http.HTTPError {
+func (server *solverServer) handleFileDownload(dirPath string, res corehttp.ResponseWriter, onCompletion func()) *http.HTTPError {
 	// Read directory contents
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -652,12 +652,12 @@ func (solverServer *solverServer) handleFileDownload(dirPath string, res corehtt
 	return nil
 }
 
-func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
+func (server *solverServer) uploadFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
 	vars := mux.Vars(req)
 	id := vars["id"]
 
 	err := func() error {
-		deal, err := solverServer.store.GetDeal(id)
+		deal, err := server.store.GetDeal(id)
 		if err != nil {
 			log.Error().Err(err).Msgf("error loading deal")
 			return err
@@ -731,11 +731,11 @@ func (solverServer *solverServer) uploadFiles(res corehttp.ResponseWriter, req *
 	}
 }
 
-func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
+func (server *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWriter, req *corehttp.Request) (EmptyResponse, error) {
 	vars := mux.Vars(req)
 	id := vars["id"]
 
-	jobOffer, err := solverServer.store.GetJobOffer(id)
+	jobOffer, err := server.store.GetJobOffer(id)
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading job offer")
 		return EmptyResponse{}, &http.HTTPError{
@@ -767,10 +767,10 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 		}
 	}
 
-	solverServer.updateJobStates(jobOffer.DealID, "ResultsAccepted")
+	server.updateJobStates(jobOffer.DealID, "ResultsAccepted")
 
 	// Retrieve deal for stats reporting
-	deal, err := solverServer.store.GetDeal(id)
+	deal, err := server.store.GetDeal(id)
 	if err != nil {
 		return EmptyResponse{}, &http.HTTPError{
 			Message:    "error loading deal",
@@ -784,9 +784,9 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 		}
 	}
 
-	if err := solverServer.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res, func() {
-		solverServer.stats.PostJobRun(deal)
-		solverServer.stats.PostReputation(deal.ResourceProvider,
+	if err := server.handleFileDownload(GetDealsFilePath(jobOffer.DealID), res, func() {
+		server.stats.PostJobRun(deal)
+		server.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).
 				Build(),
@@ -800,7 +800,7 @@ func (solverServer *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWri
 
 // Validation Service
 
-func (solverServer *solverServer) getValidationToken(res corehttp.ResponseWriter, req *corehttp.Request) (*http.ValidationToken, error) {
+func (server *solverServer) getValidationToken(res corehttp.ResponseWriter, req *corehttp.Request) (*http.ValidationToken, error) {
 	// Check signature
 	signerAddress, err := http.CheckSignature(req)
 	if err != nil {
@@ -815,15 +815,15 @@ func (solverServer *solverServer) getValidationToken(res corehttp.ResponseWriter
 		"aud":   "kafka-broker",
 		"scope": "kafka-cluster",
 		"iat":   time.Now().Unix(),
-		"exp":   time.Now().Add(time.Duration(solverServer.options.AccessControl.ValidationTokenExpiration) * time.Second).Unix(),
+		"exp":   time.Now().Add(time.Duration(server.options.AccessControl.ValidationTokenExpiration) * time.Second).Unix(),
 		"jti":   uuid.New().String(),
 	})
 
 	// Add the key ID to the token header
-	token.Header["kid"] = solverServer.options.AccessControl.ValidationTokenKid
+	token.Header["kid"] = server.options.AccessControl.ValidationTokenKid
 
 	// Sign the token
-	secret := []byte(solverServer.options.AccessControl.ValidationTokenSecret)
+	secret := []byte(server.options.AccessControl.ValidationTokenSecret)
 	tokenString, err := token.SignedString(secret)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to sign token")
@@ -834,28 +834,28 @@ func (solverServer *solverServer) getValidationToken(res corehttp.ResponseWriter
 	return &http.ValidationToken{JWT: tokenString}, nil
 }
 
-func (solverServer *solverServer) updateJobStates(dealID string, state string) error {
-	deal, err := solverServer.store.GetDeal(dealID)
+func (server *solverServer) updateJobStates(dealID string, state string) error {
+	deal, err := server.store.GetDeal(dealID)
 	if err != nil {
 		return err
 	}
 
-	_, err = solverServer.controller.updateDealState(deal.Deal.ID, data.GetAgreementStateIndex(state))
+	_, err = server.controller.updateDealState(deal.Deal.ID, data.GetAgreementStateIndex(state))
 	if err != nil {
 		return err
 	}
 	// update the job offer state
-	_, err = solverServer.controller.updateJobOfferState(deal.Deal.JobOffer.ID, deal.ID, data.GetAgreementStateIndex(state))
+	_, err = server.controller.updateJobOfferState(deal.Deal.JobOffer.ID, deal.ID, data.GetAgreementStateIndex(state))
 	if err != nil {
 		return err
 	}
 	// update the resource offer state
-	_, err = solverServer.controller.updateResourceOfferState(deal.Deal.ResourceOffer.ID, deal.ID, data.GetAgreementStateIndex(state))
+	_, err = server.controller.updateResourceOfferState(deal.Deal.ResourceOffer.ID, deal.ID, data.GetAgreementStateIndex(state))
 	if err != nil {
 		return err
 	}
 
-	solverServer.controller.writeEvent(SolverEvent{
+	server.controller.writeEvent(SolverEvent{
 		EventType: DealStateUpdated,
 		Deal:      deal,
 	})

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/solver/store"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/metric"
 	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -33,6 +33,7 @@ type Solver struct {
 	store      store.SolverStore
 	stats      stats.Stats
 	options    SolverOptions
+	log        *zerolog.Logger
 }
 
 func NewSolver(
@@ -57,13 +58,14 @@ func NewSolver(
 		server:     server,
 		web3SDK:    web3SDK,
 		options:    options,
+		log:        system.GetLogger(system.SolverService),
 	}
 	return solver, nil
 }
 
 func (solver *Solver) Start(ctx context.Context, cm *system.CleanupManager, tracerProvider *sdkTrace.TracerProvider) chan error {
 	errorChan := solver.controller.Start(ctx, cm)
-	log.Debug().Msgf("solver.server.ListenAndServe")
+	solver.log.Debug().Msgf("solver.server.ListenAndServe")
 	go func() {
 		err := solver.server.ListenAndServe(ctx, cm, tracerProvider)
 		if err != nil {

--- a/pkg/solver/solver_test.go
+++ b/pkg/solver/solver_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/solver"
 	"github.com/lilypad-tech/lilypad/pkg/solver/matcher"
-	"github.com/lilypad-tech/lilypad/pkg/system"
 	"go.opentelemetry.io/otel"
 )
 
@@ -97,7 +96,6 @@ func TestMatchingSortingLogic(t *testing.T) {
 					context.Background(),
 					store,
 					func(string, string, uint8) (*data.JobOfferContainer, error) { return nil, nil },
-					system.NewServiceLogger("solver"),
 					otel.Tracer("test"),
 					otel.Meter("test"),
 				)

--- a/pkg/solver/stats/jobrun.go
+++ b/pkg/solver/stats/jobrun.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/lilypad-tech/lilypad/pkg/module/shortcuts"
-	"github.com/rs/zerolog/log"
 )
 
 type JobRun struct {
@@ -30,7 +29,7 @@ func (stat *HTTPStats) PostJobRun(deal *data.DealContainer) error {
 		"state": data.GetAgreementStateString(deal.State),
 	})
 	if err != nil {
-		log.Error().Msgf("unable to marshal extra data: %s", err)
+		stat.log.Error().Err(err).Msg("unable to marshal extra data")
 		return err
 	}
 

--- a/pkg/solver/stats/stats.go
+++ b/pkg/solver/stats/stats.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
+	"github.com/rs/zerolog"
 )
 
 type StatsOptions struct {
@@ -28,13 +29,16 @@ func NewStats(service system.Service, options StatsOptions, web3Options web3.Web
 			PrivateKey:    web3Options.PrivateKey,
 			Type:          string(service),
 			PublicAddress: web3SDK.GetAddress().String(),
-		}}, nil
+		},
+		log: system.GetLogger(system.SolverService),
+	}, nil
 }
 
 // Stats API implementation
 
 type HTTPStats struct {
 	ClientOptions http.ClientOptions
+	log           *zerolog.Logger
 }
 
 // Noop implementation

--- a/pkg/system/context.go
+++ b/pkg/system/context.go
@@ -18,7 +18,7 @@ type CommandContext struct {
 }
 
 func NewSystemContext(ctx context.Context) *CommandContext {
-	SetupLogging()
+	SetupGlobalLogger()
 
 	cm := NewCleanupManager()
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)

--- a/pkg/system/log.go
+++ b/pkg/system/log.go
@@ -61,10 +61,13 @@ func GetLogger(service Service) *zerolog.Logger {
 	return &logger
 }
 
+// Service Logger
+
 type ServiceLogger struct {
 	service Service
 }
 
+// Get a service logger (deprecated, prefer the GetLogger in new implementations)
 func NewServiceLogger(service Service) *ServiceLogger {
 	return &ServiceLogger{
 		service: service,
@@ -111,6 +114,8 @@ func Debug(service Service, title string, data interface{}) {
 func Trace(service Service, title string, data interface{}) {
 	logWithCaller(5, zerolog.TraceLevel, service, title, data)
 }
+
+// Dump
 
 func DumpObject(d interface{}) {
 	spew.Dump(d)

--- a/pkg/system/log.go
+++ b/pkg/system/log.go
@@ -10,6 +10,28 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Global logger
+
+// Configure the default global logger
+func SetupGlobalLogger() {
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logLevelString := os.Getenv("LOG_LEVEL")
+	if logLevelString == "" {
+		logLevelString = "info"
+	}
+	logLevel := zerolog.InfoLevel
+	if logLevelString == "none" {
+		logLevel = zerolog.NoLevel
+	}
+	parsedLogLevel, err := zerolog.ParseLevel(logLevelString)
+	if err == nil {
+		logLevel = parsedLogLevel
+	}
+	zerolog.CallerSkipFrameCount = 3 // Skip 3 frames (this function, log.Output, log.Logger)
+	zerolog.SetGlobalLevel(logLevel)
+	log.Logger = log.Output(output).With().Caller().Logger().Level(logLevel)
+}
+
 type ServiceLogger struct {
 	service Service
 }
@@ -34,25 +56,6 @@ func (s *ServiceLogger) Debug(title string, data interface{}) {
 
 func (s *ServiceLogger) Trace(title string, data interface{}) {
 	Trace(s.service, title, data)
-}
-
-func SetupLogging() {
-	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
-	logLevelString := os.Getenv("LOG_LEVEL")
-	if logLevelString == "" {
-		logLevelString = "info"
-	}
-	logLevel := zerolog.InfoLevel
-	if logLevelString == "none" {
-		logLevel = zerolog.NoLevel
-	}
-	parsedLogLevel, err := zerolog.ParseLevel(logLevelString)
-	if err == nil {
-		logLevel = parsedLogLevel
-	}
-	zerolog.CallerSkipFrameCount = 3 // Skip 3 frames (this function, log.Output, log.Logger)
-	zerolog.SetGlobalLevel(logLevel)
-	log.Logger = log.Output(output).With().Caller().Logger().Level(logLevel)
 }
 
 func logWithCaller(skipFrameCount int, level zerolog.Level, service Service, title string, data interface{}) {

--- a/pkg/system/log.go
+++ b/pkg/system/log.go
@@ -32,6 +32,35 @@ func SetupGlobalLogger() {
 	log.Logger = log.Output(output).With().Caller().Logger().Level(logLevel)
 }
 
+// Logger
+
+// Get a logger configured with contextual fields
+func GetLogger(service Service) *zerolog.Logger {
+	output := zerolog.ConsoleWriter{
+		Out:        os.Stdout,
+		TimeFormat: time.RFC3339,
+		FormatMessage: func(m any) string {
+			if m == nil {
+				return ""
+			}
+			message := fmt.Sprintf("%+v", m)
+			if message != "" {
+				return fmt.Sprintf("%s %s", GetServiceBadge(service), message)
+			}
+			return message
+		},
+	}
+
+	logger := zerolog.New(output).
+		Level(log.Logger.GetLevel()).
+		With().
+		Timestamp().
+		CallerWithSkipFrameCount(2).
+		Logger()
+
+	return &logger
+}
+
 type ServiceLogger struct {
 	service Service
 }


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `GetLogger` helper to get a logger with service context
- [x] Update solver with new logger
  - [x] Add solver command logger
  - [x] Add top-level solver logger
  - [x] Replace solver controller service logger
  - [x] Add solver server logger
  - [x] Add solver metric logger
  - [x] Add solver stats logger
- [x] Rename `SetupLogging` to `SetupGlobalLogger` (to clarify its purpose)

This pull request moves us towards a uniform logging system built around the `zerolog` interface. 

We have also made a small naming change:

- [x] Rename `solverServer` instances to `server` (we know we're in the solver)

### Task/Issue reference

Implements: #303 

### Test plan

Start the stack. Run a job. Make sure it all works.

Also may be of interest to run a job and compare the logs on `main` with the logs in this pull request.

### Details

Our system currently uses a global `zerolog` implementation in some places and a service logger in others. We would like to move to individualized `zerolog` loggers for each package or component that can be configured with additional context. This pull request starts with loggers configured with the `service` they log from.

This pull request also updates the solver logs to replace global logger and service logger calls with the new contextualized logs. We have updated many of the existing logs with additional key-pairs which in some cases were not possible using the service logger. The additional key-pair fields support our upcoming OpenTelemetry work.

### Related issues or PRs

Epic: https://github.com/Lilypad-Tech/internal/issues/345
