### PR TITLE
feat: Add minimum version check

### DIFF
--- a/cmd/lilypad/solver.go
+++ b/cmd/lilypad/solver.go
@@ -79,7 +79,12 @@ func runSolver(cmd *cobra.Command, options solver.SolverOptions, network string,
 		return err
 	}
 
-	solverService, err := solver.NewSolver(options, solverStore, web3SDK, stats, tracer, meter)
+	versionConfig, err := system.NewVersionConfig(options.Server.AccessControl.MinimumVersion)
+	if err != nil {
+		return err
+	}
+
+	solverService, err := solver.NewSolver(options, solverStore, web3SDK, stats, tracer, meter, versionConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -15,6 +15,7 @@ type AccessControlOptions struct {
 	ValidationTokenKid              string
 	AnuraAddresses                  []string
 	OfferTimestampDiffSeconds       int
+	MinimumVersion                  string
 }
 
 type ValidationToken struct {

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -26,6 +26,7 @@ func GetDefaultAccessControlOptions() http.AccessControlOptions {
 		ValidationTokenKid:              GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_KID", ""),
 		AnuraAddresses:                  GetDefaultServeOptionStringArray("SERVER_ANURA_ADDRESSES", []string{}),
 		OfferTimestampDiffSeconds:       GetDefaultServeOptionInt("SERVER_OFFER_TIMESTAMP_DIFF_SECONDS", 30),
+		MinimumVersion:                  GetDefaultServeOptionString("SERVER_MINIMUM_VERSION", ""),
 	}
 }
 
@@ -84,6 +85,10 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.AccessControl.OfferTimestampDiffSeconds, "server-offer-timestamp-diff-seconds", serverOptions.AccessControl.OfferTimestampDiffSeconds,
 		`The diff before or after now when a job or resource offer must be received (SERVER_OFFER_TIMESTAMP_DIFF_SECONDS).`,
+	)
+	cmd.PersistentFlags().StringVar(
+		&serverOptions.AccessControl.MinimumVersion, "server-minimum-version", serverOptions.AccessControl.MinimumVersion,
+		`The minimum client version (SERVER_MINIMUM_VERSION).`,
 	)
 }
 

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -351,6 +351,11 @@ func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.Res
 	versionHeader, _ := http.GetVersionFromHeaders(req)
 	minVersion, ok := server.versionConfig.IsSupported(versionHeader)
 	if !ok {
+		server.log.Debug().Str("cid", jobOffer.ID).
+			Str("address", jobOffer.JobCreator).
+			Str("version", versionHeader).
+			Str("minVersion", minVersion).
+			Msg("job offer rejected because job creator is running an unsupported version")
 		return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
 	}
 
@@ -397,6 +402,11 @@ func (server *solverServer) addResourceOffer(resourceOffer data.ResourceOffer, r
 	versionHeader, _ := http.GetVersionFromHeaders(req)
 	minVersion, ok := server.versionConfig.IsSupported(versionHeader)
 	if !ok {
+		server.log.Debug().Str("cid", resourceOffer.ID).
+			Str("address", resourceOffer.ResourceProvider).
+			Str("version", versionHeader).
+			Str("minVersion", minVersion).
+			Msg("resource offer rejected because resource provider is running an unsupported version")
 		return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
 	}
 

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -30,12 +30,13 @@ import (
 )
 
 type solverServer struct {
-	options    http.ServerOptions
-	controller *SolverController
-	store      store.SolverStore
-	stats      stats.Stats
-	services   data.ServiceConfig
-	log        *zerolog.Logger
+	options       http.ServerOptions
+	controller    *SolverController
+	store         store.SolverStore
+	stats         stats.Stats
+	services      data.ServiceConfig
+	versionConfig *system.VersionConfig
+	log           *zerolog.Logger
 }
 
 func NewSolverServer(
@@ -43,14 +44,16 @@ func NewSolverServer(
 	controller *SolverController,
 	store store.SolverStore,
 	stats stats.Stats,
+	versionConfig *system.VersionConfig,
 	services data.ServiceConfig,
 ) (*solverServer, error) {
 	server := &solverServer{
-		options:    options,
-		controller: controller,
-		store:      store,
-		stats:      stats,
-		log:        system.GetLogger(system.SolverService),
+		options:       options,
+		controller:    controller,
+		store:         store,
+		stats:         stats,
+		versionConfig: versionConfig,
+		log:           system.GetLogger(system.SolverService),
 	}
 
 	metricsDashboard.Init(services.APIHost)

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -43,12 +43,13 @@ func NewSolver(
 	stats stats.Stats,
 	tracer trace.Tracer,
 	meter metric.Meter,
+	versionConfig *system.VersionConfig,
 ) (*Solver, error) {
 	controller, err := NewSolverController(web3SDK, store, options, tracer, meter)
 	if err != nil {
 		return nil, err
 	}
-	server, err := NewSolverServer(options.Server, controller, store, stats, options.Services)
+	server, err := NewSolverServer(options.Server, controller, store, stats, versionConfig, options.Services)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/system/version.go
+++ b/pkg/system/version.go
@@ -16,17 +16,22 @@ type VersionConfig struct {
 }
 
 func NewVersionConfig(minimumVersion string) (*VersionConfig, error) {
+	log := GetLogger(SolverService)
+
 	if Version != "" && !semver.IsValid(Version) {
+		log.Error().Str("version", Version).Msg("invalid embedded version")
 		return nil, fmt.Errorf("invalid embedded version: %s", Version)
 	}
 
 	if minimumVersion != "" && !semver.IsValid(minimumVersion) {
+		log.Error().Str("minVersion", minimumVersion).Msg("invalid minimum version")
 		return nil, fmt.Errorf("invalid minimum version: %s", minimumVersion)
 	}
 
 	if Version != "" &&
 		minimumVersion != "" &&
 		semver.Compare(minimumVersion, Version) > 0 {
+		log.Error().Str("minVersion", minimumVersion).Str("version", Version).Msg("minimum version greater than embedded version")
 		return nil, fmt.Errorf("minimum version %s is greater than embedded version %s", minimumVersion, Version)
 	}
 

--- a/pkg/system/version.go
+++ b/pkg/system/version.go
@@ -1,4 +1,61 @@
 package system
 
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/mod/semver"
+)
+
 var Version string
 var CommitSHA string
+
+type VersionConfig struct {
+	version        string
+	minimumVersion string
+}
+
+func NewVersionConfig(minimumVersion string) (*VersionConfig, error) {
+	if Version != "" && !semver.IsValid(Version) {
+		return nil, fmt.Errorf("invalid embedded version: %s", Version)
+	}
+
+	if minimumVersion != "" && !semver.IsValid(minimumVersion) {
+		return nil, fmt.Errorf("invalid minimum version: %s", minimumVersion)
+	}
+
+	if Version != "" &&
+		minimumVersion != "" &&
+		semver.Compare(minimumVersion, Version) > 0 {
+		return nil, fmt.Errorf("minimum version %s is greater than embedded version %s", minimumVersion, Version)
+	}
+
+	return &VersionConfig{
+		version:        Version,
+		minimumVersion: minimumVersion,
+	}, nil
+}
+
+func (vc *VersionConfig) IsSupported(version string) (string, bool) {
+	var minVersion string
+	if vc.minimumVersion != "" {
+		minVersion = vc.minimumVersion
+	} else if vc.version != "" {
+		// Use embedded major version when minimum version is not set.
+		// This option follows semantic versioning for breaking changes, so that the
+		// minimum version can be omitted when using semantic versioning.
+		minVersion = semver.Major(vc.version)
+	} else {
+		// Return supported when neither an embedded version nor minimum version is set.
+		// This condition supports local development.
+		return "", true
+	}
+
+	if !semver.IsValid(version) {
+		log.Warn().Msgf("invalid version %s", version)
+		return minVersion, false
+	}
+
+	result := semver.Compare(version, minVersion)
+	return minVersion, result >= 0 // True if version >= minVersion
+}

--- a/pkg/system/version_test.go
+++ b/pkg/system/version_test.go
@@ -1,0 +1,177 @@
+//go:build unit
+
+package system
+
+import (
+	"testing"
+)
+
+func TestIsSupported(t *testing.T) {
+	originalVersion := Version
+
+	tests := []struct {
+		name                string
+		embeddedVersion     string
+		minimumVersion      string
+		versionToCheck      string
+		expectedMinVersion  string
+		expectedIsSupported bool
+	}{
+		{
+			name:                "No embedded version nor minimum version returns true",
+			embeddedVersion:     "",
+			minimumVersion:      "",
+			versionToCheck:      "v0.1.0",
+			expectedMinVersion:  "",
+			expectedIsSupported: true,
+		},
+		{
+			name:                "No embedded version but has minimum version - newer version supported",
+			embeddedVersion:     "",
+			minimumVersion:      "v1.2.3",
+			versionToCheck:      "v1.3.0",
+			expectedMinVersion:  "v1.2.3",
+			expectedIsSupported: true,
+		},
+		{
+			name:                "No embedded version but has minimum version - older version not supported",
+			embeddedVersion:     "",
+			minimumVersion:      "v1.2.3",
+			versionToCheck:      "v1.1.0",
+			expectedMinVersion:  "v1.2.3",
+			expectedIsSupported: false,
+		},
+		{
+			name:                "No minimum version uses embedded major version - newer version supported",
+			embeddedVersion:     "v2.3.4",
+			minimumVersion:      "",
+			versionToCheck:      "v2.0.0",
+			expectedMinVersion:  "v2",
+			expectedIsSupported: true,
+		},
+		{
+			name:                "No minimum version uses embedded major version - older version not supported",
+			embeddedVersion:     "v2.3.4",
+			minimumVersion:      "",
+			versionToCheck:      "v1.9.9",
+			expectedMinVersion:  "v2",
+			expectedIsSupported: false,
+		},
+		{
+			name:                "Minimum version used when specified - newer version supported",
+			embeddedVersion:     "v3.4.5",
+			minimumVersion:      "v2.0.0",
+			versionToCheck:      "v2.1.0",
+			expectedMinVersion:  "v2.0.0",
+			expectedIsSupported: true,
+		},
+		{
+			name:                "Minimum version used when specified - exact match supported",
+			embeddedVersion:     "v3.4.5",
+			minimumVersion:      "v2.0.0",
+			versionToCheck:      "v2.0.0",
+			expectedMinVersion:  "v2.0.0",
+			expectedIsSupported: true,
+		},
+		{
+			name:                "Minimum version used when specified - older version not supported",
+			embeddedVersion:     "v3.4.5",
+			minimumVersion:      "v2.0.0",
+			versionToCheck:      "v1.9.9",
+			expectedMinVersion:  "v2.0.0",
+			expectedIsSupported: false,
+		},
+		{
+			name:                "Invalid version to check returns false",
+			embeddedVersion:     "v3.4.5",
+			minimumVersion:      "v2.0.0",
+			versionToCheck:      "invalid",
+			expectedMinVersion:  "v2.0.0",
+			expectedIsSupported: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			Version = tc.embeddedVersion
+
+			vc, err := NewVersionConfig(tc.minimumVersion)
+			if err != nil {
+				t.Fatalf("Failed to create VersionConfig: %v", err)
+			}
+
+			minVersion, isSupported := vc.IsSupported(tc.versionToCheck)
+
+			if minVersion != tc.expectedMinVersion {
+				t.Errorf("Expected min version %q, got %q", tc.expectedMinVersion, minVersion)
+			}
+
+			if isSupported != tc.expectedIsSupported {
+				t.Errorf("Expected isSupported to be %v, got %v", tc.expectedIsSupported, isSupported)
+			}
+		})
+	}
+
+	Version = originalVersion
+}
+
+func TestNewVersionConfig_Validation(t *testing.T) {
+	originalVersion := Version
+
+	tests := []struct {
+		name            string
+		embeddedVersion string
+		minimumVersion  string
+		expectError     bool
+	}{
+		{
+			name:            "Valid versions",
+			embeddedVersion: "v1.2.3",
+			minimumVersion:  "v1.0.0",
+			expectError:     false,
+		},
+		{
+			name:            "Invalid embedded version",
+			embeddedVersion: "1.2.3", // missing v prefix
+			minimumVersion:  "v1.0.0",
+			expectError:     true,
+		},
+		{
+			name:            "Invalid minimum version",
+			embeddedVersion: "v1.2.3",
+			minimumVersion:  "1.0.0", // missing v prefix
+			expectError:     true,
+		},
+		{
+			name:            "Minimum version greater than embedded version",
+			embeddedVersion: "v1.2.3",
+			minimumVersion:  "v2.0.0",
+			expectError:     true,
+		},
+		{
+			name:            "Empty embedded version is valid",
+			embeddedVersion: "",
+			minimumVersion:  "v1.0.0",
+			expectError:     false,
+		},
+		{
+			name:            "Empty minimum version is valid",
+			embeddedVersion: "v1.2.3",
+			minimumVersion:  "",
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			Version = tc.embeddedVersion
+
+			_, err := NewVersionConfig(tc.minimumVersion)
+			if (err != nil) != tc.expectError {
+				t.Errorf("Expected error: %v, got error: %v", tc.expectError, err)
+			}
+		})
+	}
+
+	Version = originalVersion
+}


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `SERVER_MINIMUM_VERSION` option and version config struct
- [x] Add minimum version check
- [x] Add version config and version check tests
- [x] Check version on resource offer and job offer post 

This pull request adds a minimum version check so we can ensure that job creators and resource providers stay up to date at a `SERVER_MINIMUM_VERSION` or newer.

### Task/Issue reference

Closes: #543 

### Test plan

We include the version at compile time, so testing this pull request will require a few compiled binaries. Start by downloading the `v2.13.0`, `v2.14.0`, and `v2.15.0` binaries from our releases page: https://github.com/Lilypad-Tech/lilypad/releases. Rename the binaries to `lilypad-v2.13.0`, `lilypad-v2.14.0`, and `lilypad-v2.15.0`

Start the base services. Start the solver with a `v2.14.0` minimum version.

```sh
./stack solver --server-minimum-version v2.14.0
```

We run the solver from source for this portion of testing because we are testing the `SERVER_MINIMUM_VERSION` setting and the compiled version does not matter.

> [!CAUTION]
> In this next portion of testing we use development-only private keys. Do not use these keys for production or any use case of consequence. Future reader you have been warned. 🔥 

Start a `v2.15.0` resource provider using our local dev private key.

```sh
WEB3_PRIVATE_KEY=0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a ./lilypad-v2.15.0 resource-provider --network dev --disable-pow true
```

Check the solver and the resource offer should increment to one resource offer.

Stop the resource provider and start the `v2.14.0` resource provider.

```sh
WEB3_PRIVATE_KEY=0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a ./lilypad-v2.14.0 resource-provider --network dev --disable-pow true
```

Once again, the resource offer should be accepted by the solver.

Stop the resource provider and start the `v2.13.0` resource provider.

```sh
WEB3_PRIVATE_KEY=0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a ./lilypad-v2.13.0 resource-provider --network dev --disable-pow true
```

The solver should start logging unsupported version errors and the resource provider will crash with the same error message after retries.

#### Semantic version

We fall back to a major version derived from the solver version when the minimum version is not set. To test this, we need to compile a binary for the solver at `v2.16.0` and another binary before `v2.0.0` for the resource provider.

```sh
go build -v -o lilypad-v2.16.0 -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=v2.16.0'"
go build -v -o lilypad-v1.52.0 -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=v1.52.0'"
```

Set the binaries to executable and then start the solver without a minimum version. The easiest way to do this is to temporarily update our `stack` solver command. Change this line:

https://github.com/Lilypad-Tech/lilypad/blob/922c3e79ced16022042affbca221b5c52389dfef/stack#L211

to

```sh
./lilypad-v2.16.0 solver --network dev "$@"
```

Then start the solver with `./stack solver`. This preserves our full local development configuration.

Now start `v1.52.0` resource provider:

```sh
WEB3_PRIVATE_KEY=0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a ./lilypad-v1.52.0 resource-provider --network dev --disable-pow true
```

The resource offer should be rejected because it is before the `v2` major version.

### Details

All versions assume a `v` prefix and will fail validation if it is missing.

#### Configs

The mininmum version can be set with an environment variable or a CLI option:

```sh
SERVER_MINIMUM_VERSION=v2.14.0 ./stack solver
./stack solver --server-minimum-version v2.14.0
```

#### Semantic versioning

The minimum version is a convenience until we move to strict semantic versioning. Once we move to strict semantic versioning, we can drop the `SERVER_MINIMUM_VERSION` config and use the solver version to determine the appropriate supported major version as minimum.

#### Local development

The solver does not have a version in local development. The `SERVER_MINIMUM_VERSION` config can be set to enforce a minimum, but the common case should avoid this because job creators and resource providers will also not have a version.