### PR TITLE
fix: Prevent duplicate job offers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,6 +190,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
+	github.com/matoous/go-nanoid/v2 v2.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -644,6 +644,8 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
+github.com/matoous/go-nanoid/v2 v2.1.0 h1:P64+dmq21hhWdtvZfEAofnvJULaRR1Yib0+PnU669bE=
+github.com/matoous/go-nanoid/v2 v2.1.0/go.mod h1:KlbGNQ+FhrUNIHUxZdL63t7tl4LaPkZNpUULS8H4uVM=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -162,9 +162,11 @@ type TargetConfig struct {
 type JobOffer struct {
 	// this is the cid of the job offer where ID is set to empty string
 	ID string `json:"id"`
-	// Acts as a nonce so we don't have one ID pointing at multiple offers.
-	// Also used as the starting time when recording job run times.
+	// Checked for recency on the solver and the
+	// starting point for job run times
 	CreatedAt int `json:"created_at"`
+	// Prevents offers with duplicate IDs
+	Nonce string `json:"nonce"`
 	// the address of the job creator
 	JobCreator string `json:"job_creator"`
 	// the actual module that is being offered

--- a/pkg/jobcreator/utils.go
+++ b/pkg/jobcreator/utils.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/module"
+
+	nanoid "github.com/matoous/go-nanoid/v2"
 )
 
 // this will load the module in the offer options
@@ -18,9 +20,16 @@ func getJobOfferFromOptions(options JobCreatorOfferOptions, jobCreatorAddress st
 		return data.JobOffer{}, fmt.Errorf("error loading module: %s opts=%+v", err.Error(), options)
 	}
 
+	// Generate a nonce to make sure the job offer is unique
+	nonce, err := nanoid.New()
+	if err != nil {
+		return data.JobOffer{}, fmt.Errorf("error generating job offer nonce: %v", err)
+	}
+
 	return data.JobOffer{
 		// assign CreatedAt to the current millisecond timestamp
 		CreatedAt:  int(time.Now().UnixNano() / int64(time.Millisecond)),
+		Nonce:      nonce,
 		JobCreator: jobCreatorAddress,
 		Module:     options.Module,
 		Spec:       loadedModule.Machine,


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add job offer nonce

This pull request adds a nonce to job offers to ensure they are unique.

### Test plan

Start the stack. Run multiple jobs in parallel using the same input. Job offers with matching timestamps should remain have unique CIDs with the new nonce.

### Details

Job offers include a `CreatedAt` field that acts as a nonce to distinguish them, but we have found that job offers created in parallel with the same input may not be unique when timestamps collide. We have added a nonce to ensure job offers are not duplicated. 
