### PR TITLE
chore: Log job offer CID at run start

### DIFF
--- a/pkg/jobcreator/run.go
+++ b/pkg/jobcreator/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lilypad-tech/lilypad/pkg/data"
 	"github.com/lilypad-tech/lilypad/pkg/system"
 	"github.com/lilypad-tech/lilypad/pkg/web3"
+	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -43,6 +44,12 @@ func RunJob(
 	if err != nil {
 		return nil, err
 	}
+
+	jobOfferID, err := data.GetJobOfferID(offer)
+	if err != nil {
+		return nil, err
+	}
+	log.Info().Str("cid", jobOfferID).Msg("sending job offer")
 
 	// wait a short period because we've just started the job creator service
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Log job offer CID at run start

We would like to make the job offer CID easily accessible in logs for debugging purposes. 

### Test plan

Start the stack. Run a job. The job offer CID should log early on.
