### PR TITLE
fix: Add explicit NVIDIA device reservation to Resource Provider docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,13 @@ services:
     depends_on:
       bacalhau:
         condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     build:
       context: ..
       dockerfile: ./docker/resource-provider/Dockerfile


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [ x ] Adds a new `deploy` block to the Resource Provider

I was attempting to start a node on Ubuntu 22.04 by following the [Run a Node](https://docs.lilypad.tech/lilypad/resource-providers/run-a-node) docs. On two different servers, I ran into an error on the Resource Provider while attempting to start the Docker Compose services: `/usr/local/bin/lilypad: error while loading shared libraries: libcuda.so.1: cannot open shared object file`

I confirmed that my NVIDIA Container Toolkit was working by running a container that ran `nvidia-smi`, which returned the GPU's information, proving my containers could access it. Adding the extra `deploy` block in this PR solved the issue for me, and it seems from the Docker Compose [GPU support docs](https://docs.docker.com/compose/how-tos/gpu-support/)
 that this block is required. 

A second beta RP user reported this issue in the Discord as well. 

### Task/Issue reference

Closes: https://github.com/Lilypad-Tech/lilypad/issues/548 

### Test plan

You can test this by using the new compose file through the same steps in the Run a Node docs.
