### PR TITLE
feat: Add minimum version check enabled option

### DIFF
--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -15,6 +15,7 @@ type AccessControlOptions struct {
 	ValidationTokenKid              string
 	AnuraAddresses                  []string
 	OfferTimestampDiffSeconds       int
+	EnableVersionCheck              bool
 	MinimumVersion                  string
 }
 

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+
 	"github.com/lilypad-tech/lilypad/pkg/http"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,7 @@ func GetDefaultAccessControlOptions() http.AccessControlOptions {
 		ValidationTokenKid:              GetDefaultServeOptionString("SERVER_VALIDATION_TOKEN_KID", ""),
 		AnuraAddresses:                  GetDefaultServeOptionStringArray("SERVER_ANURA_ADDRESSES", []string{}),
 		OfferTimestampDiffSeconds:       GetDefaultServeOptionInt("SERVER_OFFER_TIMESTAMP_DIFF_SECONDS", 30),
+		EnableVersionCheck:              GetDefaultServeOptionBool("SERVER_ENABLE_VERSION_CHECK", true),
 		MinimumVersion:                  GetDefaultServeOptionString("SERVER_MINIMUM_VERSION", ""),
 	}
 }
@@ -84,6 +86,10 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.AccessControl.OfferTimestampDiffSeconds, "server-offer-timestamp-diff-seconds", serverOptions.AccessControl.OfferTimestampDiffSeconds,
 		`The diff before or after now when a job or resource offer must be received (SERVER_OFFER_TIMESTAMP_DIFF_SECONDS).`,
+	)
+	cmd.PersistentFlags().BoolVar(
+		&serverOptions.AccessControl.EnableVersionCheck, "server-enable-version-check", serverOptions.AccessControl.EnableVersionCheck,
+		`Enable version check (SERVER_ENABLE_VERSION_CHECK).`,
 	)
 	cmd.PersistentFlags().StringVar(
 		&serverOptions.AccessControl.MinimumVersion, "server-minimum-version", serverOptions.AccessControl.MinimumVersion,

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -348,15 +348,17 @@ func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.Res
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
 
-	versionHeader, _ := http.GetVersionFromHeaders(req)
-	minVersion, ok := server.versionConfig.IsSupported(versionHeader)
-	if !ok {
-		server.log.Debug().Str("cid", jobOffer.ID).
-			Str("address", jobOffer.JobCreator).
-			Str("version", versionHeader).
-			Str("minVersion", minVersion).
-			Msg("job offer rejected because job creator is running an unsupported version")
-		return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
+	if server.options.AccessControl.EnableVersionCheck {
+		versionHeader, _ := http.GetVersionFromHeaders(req)
+		minVersion, ok := server.versionConfig.IsSupported(versionHeader)
+		if !ok {
+			server.log.Debug().Str("cid", jobOffer.ID).
+				Str("address", jobOffer.JobCreator).
+				Str("version", versionHeader).
+				Str("minVersion", minVersion).
+				Msg("job offer rejected because job creator is running an unsupported version")
+			return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
+		}
 	}
 
 	offerRecent := isTimestampRecent(jobOffer.CreatedAt, server.options.AccessControl.OfferTimestampDiffSeconds*1000)
@@ -399,15 +401,17 @@ func (server *solverServer) addResourceOffer(resourceOffer data.ResourceOffer, r
 		}
 	}
 
-	versionHeader, _ := http.GetVersionFromHeaders(req)
-	minVersion, ok := server.versionConfig.IsSupported(versionHeader)
-	if !ok {
-		server.log.Debug().Str("cid", resourceOffer.ID).
-			Str("address", resourceOffer.ResourceProvider).
-			Str("version", versionHeader).
-			Str("minVersion", minVersion).
-			Msg("resource offer rejected because resource provider is running an unsupported version")
-		return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
+	if server.options.AccessControl.EnableVersionCheck {
+		versionHeader, _ := http.GetVersionFromHeaders(req)
+		minVersion, ok := server.versionConfig.IsSupported(versionHeader)
+		if !ok {
+			server.log.Debug().Str("cid", resourceOffer.ID).
+				Str("address", resourceOffer.ResourceProvider).
+				Str("version", versionHeader).
+				Str("minVersion", minVersion).
+				Msg("resource offer rejected because resource provider is running an unsupported version")
+			return nil, fmt.Errorf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion)
+		}
 	}
 
 	offerRecent := isTimestampRecent(resourceOffer.CreatedAt, server.options.AccessControl.OfferTimestampDiffSeconds*1000)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `SERVER_ENABLE_VERSION_CHECK` option

We want to be able to enable and disable the minimum version check

### Test plan

Compile a `v2.12.0` binary:

```sh
go build -v -o lilypad-v2.12.0 -ldflags="-X 'github.com/lilypad-tech/lilypad/pkg/system.Version=v2.12.0'"
```

Start the base services and the solver with:

```sh
./stack solver --server-minimum-version v2.14.0
```

Start a `v2.12.0` resource provider using the compiled binary. The resource offer should be rejected.

Now restart the solver with:

```
./stack solver --server-minimum-version v2.14.0 --server-enable-version-check false
```

Restart the resource provider and the resource offer should be accepted.

