### PR TITLE
fix: Exempt Anura from version check

### DIFF
--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -225,6 +225,30 @@ func CheckAnuraSignature(req *http.Request, approvedAddresses []string) (string,
 	}
 }
 
+func IsAnura(req *http.Request, approvedAddresses []string) bool {
+	serverHeader := req.Header.Get(X_ANURA_SERVER_HEADER)
+	if serverHeader == "" {
+		return false
+	}
+	anuraSignature := req.Header.Get(X_ANURA_SIGNATURE_HEADER)
+	if anuraSignature == "" {
+		return false
+	}
+
+	signatureAddress, err := decodeUserAddress(serverHeader, anuraSignature)
+	if err != nil {
+		return false
+	}
+
+	for _, addr := range approvedAddresses {
+		if strings.EqualFold(signatureAddress, addr) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func GetVersionFromHeaders(req *http.Request) (string, error) {
 	versionHeader := req.Header.Get(X_LILYPAD_VERSION_HEADER)
 	if versionHeader == "" {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -348,7 +348,7 @@ func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.Res
 		return nil, fmt.Errorf("job creator address does not match signer address")
 	}
 
-	if server.options.AccessControl.EnableVersionCheck {
+	if server.options.AccessControl.EnableVersionCheck && !http.IsAnura(req, server.options.AccessControl.AnuraAddresses) {
 		versionHeader, _ := http.GetVersionFromHeaders(req)
 		minVersion, ok := server.versionConfig.IsSupported(versionHeader)
 		if !ok {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Exempt Anura from version check

We recently added a minimum version check (#544) for job offers and resource offers. This check works for resource providers and job creators versioned in this repo, but it does not work for Anura.

This pull request adds an exemption from the version check for Anura.

### Task/Issue reference

Implements:  #543

### Test plan

Start the base services and solver with:

```sh
SERVER_MINIMUM_VERSION=v2.14.0 ./stack solver
```

This assumes the local dev `SERVER_ANURA_ADDRESSES` set in `.local.dev`: https://github.com/Lilypad-Tech/lilypad/blob/37e86a39122a54260d72d853e7282f1925c0a70c/.local.dev#L33

Remove the `X-Lilypad-Version` header changed recently in Anura (https://github.com/Lilypad-Tech/anura/pull/20/files). The missing version would cause a CLI job offer to be rejected, but Anura should be exempt.

Start Anura and send some jobs. They should post.
