### PR TITLE
Add NVIDIA runtime support & WebUI port to docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   bacalhau:
     image: ghcr.io/lilypad-tech/bacalhau:latest
     container_name: bacalhau
+    ports:
+      - "8438:8438"
+    command: ["bacalhau", "serve", "--orchestrator", "--compute", "--config", "WebUI.Enabled"]
+    runtime: nvidia
     restart: unless-stopped
     privileged: true
     build:
@@ -10,23 +14,17 @@ services:
       dockerfile: ./docker/bacalhau/Dockerfile
     environment:
       - BACALHAU_ENVIRONMENT=local
-    command: ["bacalhau", "serve", "--orchestrator", "--compute"]
+      - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - bacalhau-data:/root/.bacalhau
   resource-provider:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider
+    runtime: nvidia
     restart: unless-stopped
     depends_on:
       bacalhau:
         condition: service_healthy
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
     build:
       context: ..
       dockerfile: ./docker/resource-provider/Dockerfile
@@ -37,6 +35,7 @@ services:
       - bacalhau-data:/root/.bacalhau
     environment:
       - WEB3_PRIVATE_KEY
+      - NVIDIA_VISIBLE_DEVICES=all
       - WEB3_RPC_URL
       - BACALHAU_API_HOST=bacalhau
       - BACALHAU_NODE_CLIENTAPI_HOST=bacalhau

--- a/testfile.txt
+++ b/testfile.txt
@@ -1,0 +1,1 @@
+Testing SSH commit signing


### PR DESCRIPTION
**Summary of Changes**

- Expose port `8438` in Bacalhau container to enable the Web UI
- Enable `--config WebUI.Enabled` in Bacalhau command
- Add `runtime: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` to both Bacalhau and Resource Provider services
- Remove GPU reservations in favor of explicitly specifying the NVIDIA runtime
- Retain original watchtower service and volume mappings

**Detailed Description**

This PR updates the `docker-compose.yml` to allow GPU support through the NVIDIA runtime and enable the Bacalhau Web UI port. The changes include:

1. **GPU Support**  
   - Added `runtime: nvidia` to both the `bacalhau` and `resource-provider` services.  
   - Set the environment variable `NVIDIA_VISIBLE_DEVICES=all` for GPU recognition in containers.

2. **Web UI**  
   - Exposed Bacalhau Web UI port (`8438:8438`) and included `--config WebUI.Enabled` in the Bacalhau command.

3. **Other Adjustments**  
   - Removed explicit GPU device reservation in `resource-provider` in favor of NVIDIA runtime.  
   - Maintained watchtower service as is.

**Files Changed**

- `docker-compose.yml`

```diff
# This is a docker-compose file for use by Resource Providers
 services:
   bacalhau:
     image: ghcr.io/lilypad-tech/bacalhau:latest
     container_name: bacalhau
+    ports:
+      - "8438:8438"
+    command: ["bacalhau", "serve", "--orchestrator", "--compute", "--config", "WebUI.Enabled"]
+    runtime: nvidia
     restart: unless-stopped
     privileged: true
     build:
       context: ..
       dockerfile: ./docker/bacalhau/Dockerfile
     environment:
       - BACALHAU_ENVIRONMENT=local
+      - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - bacalhau-data:/root/.bacalhau

   resource-provider:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider
+    runtime: nvidia
     restart: unless-stopped
     depends_on:
       bacalhau:
         condition: service_healthy
     build:
       context: ..
       dockerfile: ./docker/resource-provider/Dockerfile
       args:
         - COMPUTE_MODE=gpu
     volumes:
       - lilypad-data:/tmp/lilypad/data
       - bacalhau-data:/root/.bacalhau
     environment:
       - WEB3_PRIVATE_KEY
+      - NVIDIA_VISIBLE_DEVICES=all
       - WEB3_RPC_URL
       - BACALHAU_API_HOST=bacalhau
       - BACALHAU_NODE_CLIENTAPI_HOST=bacalhau
       - BACALHAU_NODE_CLIENTAPI_PORT=1234

   watchtower:
     image: containrrr/watchtower
     container_name: watchtower
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

 volumes:
   bacalhau-data:
   lilypad-data:
```

**Testing**

1. **Local Testing**  
   - Run `docker-compose up -d` with the updated file.  
   - Confirm containers start without errors.  
   - Access the Bacalhau Web UI on `http://localhost:8438`.

2. **GPU Check**  
   - Run an internal GPU job on Bacalhau or test GPU usage inside the container to confirm GPU support.

**Additional Notes**

- If you notice any issues with GPU detection, ensure you have the correct NVIDIA drivers installed and Docker configured for `nvidia-container-runtime`.

---