### PR TITLE
feat: sign CLA for B0bbyDowns

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -19,7 +19,8 @@
     "DevlinRocha",
     "zhuhaicity",
     "jdelamare",
-    "0xThresh"
+    "0xThresh",
+    "B0bbyDowns"
   ],
   "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please open a new pull request and sign the Contributor License Agreement following the instructions in our [contributing guide](https://github.com/Lilypad-Tech/lilypad/blob/main/CONTRIBUTING.md#contributor-license-agreement). Once the pull request is merged, ping a maintainer who will summon me again."
 }

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -114,3 +114,9 @@ Licensee’s name: James Westbrook
 Repository system identifier: 0xThresh
 
 ---------------------------------------------------------------------------------
+
+Licensee’s name: Bob Downs
+
+Repository system identifier: B0bbyDowns
+
+---------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
I am adding my name and GitHub username to `NOTICES.md` to sign the CLA. I could not locate a `.clabot` file, so I'm assuming it's no longer required or has been removed. Let me know if there's anything else needed.

### Details
- Added the following entry to `NOTICES.md`:

- All commits on this pull request are signed as requested.

### Test plan
No functional changes; simply documentation updates for CLA signing. 
