### PR TITLE
feat: Reduce solver control loop triggers

### DIFF
--- a/pkg/solver/controller.go
+++ b/pkg/solver/controller.go
@@ -160,8 +160,6 @@ func (controller *SolverController) subscribeToWeb3() error {
 		}
 		controller.log.Info().Str("StorageDealStateChange", data.GetAgreementStateString(ev.State)).Msg("")
 		system.DumpObjectDebug(ev)
-		// update the store with the state change
-		controller.loop.Trigger()
 	})
 
 	// update the mediator
@@ -173,9 +171,6 @@ func (controller *SolverController) subscribeToWeb3() error {
 			controller.log.Error().Err(err).Msg("error updating deal state")
 			return
 		}
-
-		// update the store with the state change
-		controller.loop.Trigger()
 	})
 
 	return nil

--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/lilypad-tech/lilypad/v2/pkg/data"
 	"github.com/lilypad-tech/lilypad/v2/pkg/solver/store"
+	"github.com/lilypad-tech/lilypad/v2/pkg/system"
+	"github.com/rs/zerolog"
 	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -13,7 +15,8 @@ import (
 )
 
 type SolverStoreDatabase struct {
-	db *gorm.DB
+	db  *gorm.DB
+	log *zerolog.Logger
 }
 
 func NewSolverStoreDatabase(connStr string, gormLogLevel string) (*SolverStoreDatabase, error) {
@@ -45,7 +48,9 @@ func NewSolverStoreDatabase(connStr string, gormLogLevel string) (*SolverStoreDa
 	db.AutoMigrate(&MatchDecision{})
 	db.AutoMigrate(&AllowedResourceProvider{})
 
-	return &SolverStoreDatabase{db}, nil
+	log := system.GetLogger(system.SolverService)
+
+	return &SolverStoreDatabase{db, log}, nil
 }
 
 func (store *SolverStoreDatabase) AddJobOffer(jobOffer data.JobOfferContainer) (*data.JobOfferContainer, error) {
@@ -185,6 +190,7 @@ func (store *SolverStoreDatabase) GetJobOffers(query store.GetJobOffersQuery) ([
 
 	var records []JobOffer
 	if err := q.Find(&records).Error; err != nil {
+		store.log.Error().Err(err).Msg("retrieve job offers from database failed")
 		return nil, err
 	}
 
@@ -218,6 +224,7 @@ func (store *SolverStoreDatabase) GetResourceOffers(query store.GetResourceOffer
 
 	var records []ResourceOffer
 	if err := q.Find(&records).Error; err != nil {
+		store.log.Error().Err(err).Msg("retrieve resource offers from database failed")
 		return nil, err
 	}
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Remove solver control loop triggers on web3 events
- [x] Add logging in matcher and store implementations

We would like to reduce the number of events that trigger the solver control loop for a few reasons:

- We have noticed control loop iterations that do not perform useful work (`solve` traces complete in <1ms)
- The web3 event triggers are less relevant with the new protocol
- Rapid control loop iterations may be contributing to controller instability

We also considered removing the control loop trigger when a resource offer is added, but decided against it. This trigger progresses work when there are queued job offers. When a resource offer is posted, we can attempt to match it with a job offer immediately.

We have also added a few logs for better visibility in the store and matcher.

### Test plan

Start the stack. Run a few jobs.
