### PR TITLE
build: Add Grafana alert repository dispatch

### DIFF
--- a/.github/workflows/testnet_restart_solver.yml
+++ b/.github/workflows/testnet_restart_solver.yml
@@ -1,6 +1,11 @@
 name: Restart Testnet solver
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - grafana_alert
+
 
 jobs:
   solver-restart:


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add repository dispatch to trigger solver restarts with a webhook

We would like to autmoate restarting the solver. Repository dispatch gives us a webhook endpoint to trigger the Restart Testnet solver action.

Repository dispatch docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
