### PR TITLE
chore: Add target span attribute to CLI job run traces

### DIFF
--- a/pkg/jobcreator/run.go
+++ b/pkg/jobcreator/run.go
@@ -61,6 +61,7 @@ func RunJob(
 			attribute.String("job_offer.module.repo", offer.Module.Repo),
 			attribute.String("job_offer.module.hash", offer.Module.Hash),
 			attribute.String("job_offer.mode", string(offer.Mode)),
+			attribute.String("job_offer.target.address", string(offer.Target.Address)),
 		))
 	ctx.Ctx = c
 	defer span.End()


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `job_offer.target.address` span attribute to CLI run `run_job` trace

We would like to be able to query by target address when examining CLI job runs.

### Test plan

Start the stack. Run a job targeting our local development resource provider:

```sh
./stack run cowsay:v0.0.4 -i Message="airy" --target 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
```

Query the traces with the target span attribute:

```
{resource.service.name="job_creator" && name="run_job" && status=unset && span.job_offer.target.address="0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"}
```

The `unset` status indicates a trace that did not have an error. To query for traces with errors:

```
{resource.service.name="job_creator" && name="run_job" && status=error && span.job_offer.target.address="0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"}
```

Investigate the span events to determine what went wrong.