### PR TITLE
fix: Target unmatched resource offers

### DIFF
--- a/pkg/solver/store/db/db.go
+++ b/pkg/solver/store/db/db.go
@@ -358,21 +358,6 @@ func (store *SolverStoreDatabase) GetResourceOffer(id string) (*data.ResourceOff
 	return &resourceOffer, nil
 }
 
-func (store *SolverStoreDatabase) GetResourceOfferByAddress(address string) (*data.ResourceOfferContainer, error) {
-	var record ResourceOffer
-	result := store.db.Where("resource_provider = ?", address).First(&record)
-
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		return nil, result.Error
-	}
-
-	resourceOffer := record.Attributes.Data()
-	return &resourceOffer, nil
-}
-
 func (store *SolverStoreDatabase) GetDeal(id string) (*data.DealContainer, error) {
 	// Deals are unique by CID, so we can query first
 	var record Deal

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -265,17 +265,6 @@ func (s *SolverStoreMemory) GetResourceOffer(id string) (*data.ResourceOfferCont
 	return resourceOffer, nil
 }
 
-func (s *SolverStoreMemory) GetResourceOfferByAddress(address string) (*data.ResourceOfferContainer, error) {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	for _, resourceOffer := range s.resourceOfferMap {
-		if strings.EqualFold(resourceOffer.ResourceProvider, address) {
-			return resourceOffer, nil
-		}
-	}
-	return nil, nil
-}
-
 func (s *SolverStoreMemory) GetDeal(id string) (*data.DealContainer, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -82,7 +82,6 @@ type SolverStore interface {
 	GetAllowedResourceProviders() ([]string, error)
 	GetJobOffer(id string) (*data.JobOfferContainer, error)
 	GetResourceOffer(id string) (*data.ResourceOfferContainer, error)
-	GetResourceOfferByAddress(address string) (*data.ResourceOfferContainer, error)
 	GetDeal(id string) (*data.DealContainer, error)
 	GetResult(id string) (*data.Result, error)
 	GetMatchDecision(resourceOffer string, jobOffer string) (*data.MatchDecision, error)

--- a/pkg/solver/store/store_test.go
+++ b/pkg/solver/store/store_test.go
@@ -465,18 +465,6 @@ func TestResourceOfferOps(t *testing.T) {
 					t.Errorf("Expected ID %s, got %s", resourceOffer.ID, retrieved.ID)
 				}
 
-				// Get resource offer by address
-				byAddress, err := store.GetResourceOfferByAddress(resourceOffer.ResourceProvider)
-				if err != nil {
-					t.Fatalf("Failed to get resource offer by address: %v", err)
-				}
-				if byAddress == nil {
-					t.Fatalf("Expected resource offer by address, got nil")
-				}
-				if byAddress.ResourceProvider != resourceOffer.ResourceProvider {
-					t.Errorf("Expected provider %s, got %s", resourceOffer.ResourceProvider, byAddress.ResourceProvider)
-				}
-
 				// Update resource offer
 				newDealID := generateCID()
 				newState := generateState()
@@ -503,15 +491,6 @@ func TestResourceOfferOps(t *testing.T) {
 				}
 				if removed != nil {
 					t.Error("Resource offer still exists after removal")
-				}
-
-				// Verify removal by address
-				removedByAddr, err := store.GetResourceOfferByAddress(resourceOffer.ResourceProvider)
-				if err != nil {
-					t.Fatalf("Error checking removed resource offer by address: %v", err)
-				}
-				if removedByAddr != nil {
-					t.Error("Resource offer still exists after removal when checking by address")
 				}
 			}
 		})


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Target unmatched resources offers
- [x] Remove `GetResourceOfferByAddress` store method

This pull request fixes an edge case where already matched resource offers could be targeted. The changes query the store for unmatched resource offers, and we make a deal with one if found.

Note that we recently merged changes to prevent duplicate resource offers in #566.

The `GetResourceOfferByAddress` store method was only used for targeting, so we have removed it.

### Test plan

Start the stack and run a job targeting the local development resource provider:

```sh
./stack run cowsay:v0.0.4 -i Message="airy" --target 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
```

This should succeed. Now run a job targeting a non-existent resource provider:

```sh
./stack run cowsay:v0.0.4 -i Message="airy" --target 0x11111111111
```

The job should return quickly with a job cancelled error message.

Now run two jobs in quick succession targeting the local development resource provider. While the first job is running, the second job should be rejected because an unmatched resource offer is not available.
