### PR TITLE
feat: Add module metadata fields

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -38,6 +38,13 @@ type GPUSpec struct {
 
 // this is what is loaded from the template file in the git repo
 type Module struct {
+	Author      ModuleAuthor `json:"author"`
+	Description string       `json:"description"`
+
+	// An image URL
+	Image string      `json:"image"`
+	Model ModuleModel `json:"model"`
+
 	// the min spec that this module requires
 	// e.g. does this module need a GPU?
 	// the module file itself will contain this spec
@@ -47,6 +54,20 @@ type Module struct {
 
 	// the bacalhau job spec
 	Job bacalhau.Job `json:"job"`
+}
+
+type ModuleAuthor struct {
+	Name string `json:"name"`
+
+	// An Avatar URL
+	Avatar  string `json:"avatar"`
+	Address string `json:"address"`
+}
+
+type ModuleModel struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Size string `json:"size"`
 }
 
 // describes a workload to be run


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add module `author` fields
- [x] Add module `model` fields
- [x] Add module `image` URL field
- [x] Add module `description` field

This pull request extends the module spec to include metadata about the module author, description, image URL and model.

We don't currently use these fields in the core system, but we may want to validate them when loading modules in the future. In addition, the `Module` type is currently our best source of truth for what fields a module contains.
