### PR TITLE
feat: Add job file inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,18 @@ jobs:
           ./stack compose-services -d
           sleep 5
 
+      - name: Create data directories
+        run: |
+          mkdir -p ${{ github.workspace }}/sol
+          chmod -R 777 ${{ github.workspace }}/sol
+          mkdir -p ${{ github.workspace }}/rp
+          chmod -R 777 ${{ github.workspace }}/rp
+          mkdir -p ${{ github.workspace }}/jc
+          chmod -R 777 ${{ github.workspace }}/jc
+
       - name: Start solver
+        env:
+          DATA_DIR: ${{ github.workspace }}/sol
         run: |
           ./stack solver --disable-telemetry=true --api-host="" > solver.log &
           sleep 20
@@ -59,11 +70,15 @@ jobs:
         run: ./stack integration-tests-solver
 
       - name: Start resource provider
+        env:
+          DATA_DIR: ${{ github.workspace }}/rp
         run: |
           ./stack resource-provider --disable-telemetry=true --api-host="" > resource-provider.log &
           sleep 5
 
       - name: Run main integration tests
+        env:
+          DATA_DIR: ${{ github.workspace }}/jc
         run: ./stack integration-tests
 
       - name: Display solver logs

--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -63,9 +63,11 @@ services:
     ports:
       - 1234:1234
       - 6001:6001
-    command: ["bacalhau", "serve", "--orchestrator", "--compute"]
+    command: |-
+      bacalhau serve --orchestrator --compute --config Compute.AllowListedLocalPaths="/inputs/*:rw"
     volumes:
       - bacalhau-data:/root/.bacalhau
+      - /tmp/lilypad/data/job-inputs/:/inputs
 volumes:
   bacalhau-data:
   chain-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,9 +10,11 @@ services:
       dockerfile: ./docker/bacalhau/Dockerfile
     environment:
       - BACALHAU_ENVIRONMENT=local
-    command: ["bacalhau", "serve", "--orchestrator", "--compute"]
+    command: |-
+      bacalhau serve --orchestrator --compute --config Compute.AllowListedLocalPaths="/inputs/*:rw"
     volumes:
       - bacalhau-data:/root/.bacalhau
+      - /tmp/lilypad/data/job-inputs/:/inputs
   resource-provider:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 h1:VNqngBF40hVlDloBruUehVYC3Ar
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1/go.mod h1:RBRO7fro65R6tjKzYgLAFo0t1QEXY1Dp+i/bvpRiqiQ=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -45,6 +45,9 @@ type Module struct {
 	Image string      `json:"image"`
 	Model ModuleModel `json:"model"`
 
+	// Expected input files
+	InputFiles InputFiles `json:"inputFiles"`
+
 	// the min spec that this module requires
 	// e.g. does this module need a GPU?
 	// the module file itself will contain this spec
@@ -68,6 +71,11 @@ type ModuleModel struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 	Size string `json:"size"`
+}
+
+type InputFiles struct {
+	Required []string `json:"required"`
+	Optional []string `json:"optional"`
 }
 
 // describes a workload to be run

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -207,6 +207,8 @@ type JobOffer struct {
 	// the user inputs to the module
 	// these values will power the go template
 	Inputs map[string]string `json:"inputs"`
+	// Expected input files
+	InputFiles InputFiles `json:"inputFiles"`
 	// tells the solver how to match these prices
 	// for JC this will normally be MarketPrice
 	Mode PricingMode `json:"mode"`

--- a/pkg/executor/bacalhau/bacalhau.go
+++ b/pkg/executor/bacalhau/bacalhau.go
@@ -258,7 +258,7 @@ func (executor *BacalhauExecutor) getJobID(
 	deal data.DealContainer,
 	module data.Module,
 ) (string, error) {
-	putJobResponse, err := executor.bacalhauClient.postJob(module.Job)
+	putJobResponse, err := executor.bacalhauClient.postJob(module.Job, deal.ID)
 	if err != nil {
 		return "", fmt.Errorf("error creating job %s -> %s", deal.ID, err.Error())
 	}

--- a/pkg/executor/bacalhau/bacalhau.go
+++ b/pkg/executor/bacalhau/bacalhau.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
 	executorlib "github.com/Lilypad-Tech/lilypad/v2/pkg/executor"
+	modulelib "github.com/Lilypad-Tech/lilypad/v2/pkg/module"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/ipfs/boxo/files"
@@ -258,7 +259,8 @@ func (executor *BacalhauExecutor) getJobID(
 	deal data.DealContainer,
 	module data.Module,
 ) (string, error) {
-	putJobResponse, err := executor.bacalhauClient.postJob(module.Job, deal.ID)
+	hasInputFiles := modulelib.HasInputFiles(module.InputFiles)
+	putJobResponse, err := executor.bacalhauClient.postJob(module.Job, deal.ID, hasInputFiles)
 	if err != nil {
 		return "", fmt.Errorf("error creating job %s -> %s", deal.ID, err.Error())
 	}

--- a/pkg/executor/bacalhau/client.go
+++ b/pkg/executor/bacalhau/client.go
@@ -52,9 +52,8 @@ func (c *BacalhauClient) getVersion() (string, error) {
 	return response.BuildVersionInfo.GitVersion, nil
 }
 
-func (c *BacalhauClient) postJob(job bacalhau.Job) (*apimodels.PutJobResponse, error) {
-
-	translatedJob := translateJob(job)
+func (c *BacalhauClient) postJob(job bacalhau.Job, dealID string) (*apimodels.PutJobResponse, error) {
+	translatedJob := translateJob(job, dealID)
 
 	putJobRequest := apimodels.PutJobRequest{
 		Job: translatedJob,
@@ -128,7 +127,7 @@ func (c *BacalhauClient) getMachineSpecs() ([]data.MachineSpec, error) {
 	return specs, nil
 }
 
-func translateJob(job bacalhau.Job) *models.Job {
+func translateJob(job bacalhau.Job, dealID string) *models.Job {
 	return &models.Job{
 		ID:        job.Metadata.ID,
 		Name:      job.Metadata.ID,
@@ -167,6 +166,16 @@ func translateJob(job bacalhau.Job) *models.Job {
 					ExecutionTimeout: job.Spec.Timeout,
 					// TODO: add queue timeout and total timeout
 				},
+				InputSources: []*models.InputSource{&models.InputSource{
+					Source: &models.SpecConfig{
+						Type: "localDirectory",
+						Params: map[string]any{
+							"SourcePath": fmt.Sprintf("/inputs/%s", dealID),
+							"ReadWrite":  true,
+						},
+					},
+					Target: "/inputs",
+				}},
 				ResultPaths: translateOutputSources(job.Spec.Outputs),
 			},
 		},

--- a/pkg/executor/bacalhau/client.go
+++ b/pkg/executor/bacalhau/client.go
@@ -52,8 +52,8 @@ func (c *BacalhauClient) getVersion() (string, error) {
 	return response.BuildVersionInfo.GitVersion, nil
 }
 
-func (c *BacalhauClient) postJob(job bacalhau.Job, dealID string) (*apimodels.PutJobResponse, error) {
-	translatedJob := translateJob(job, dealID)
+func (c *BacalhauClient) postJob(job bacalhau.Job, dealID string, hasInputFiles bool) (*apimodels.PutJobResponse, error) {
+	translatedJob := translateJob(job, dealID, hasInputFiles)
 
 	putJobRequest := apimodels.PutJobRequest{
 		Job: translatedJob,
@@ -127,7 +127,21 @@ func (c *BacalhauClient) getMachineSpecs() ([]data.MachineSpec, error) {
 	return specs, nil
 }
 
-func translateJob(job bacalhau.Job, dealID string) *models.Job {
+func translateJob(job bacalhau.Job, dealID string, hasInputFiles bool) *models.Job {
+	var inputSources []*models.InputSource
+	if hasInputFiles {
+		inputSources = append(inputSources, &models.InputSource{
+			Source: &models.SpecConfig{
+				Type: "localDirectory",
+				Params: map[string]any{
+					"SourcePath": fmt.Sprintf("/inputs/%s", dealID),
+					"ReadWrite":  true,
+				},
+			},
+			Target: "/inputs",
+		})
+	}
+
 	return &models.Job{
 		ID:        job.Metadata.ID,
 		Name:      job.Metadata.ID,
@@ -166,17 +180,8 @@ func translateJob(job bacalhau.Job, dealID string) *models.Job {
 					ExecutionTimeout: job.Spec.Timeout,
 					// TODO: add queue timeout and total timeout
 				},
-				InputSources: []*models.InputSource{&models.InputSource{
-					Source: &models.SpecConfig{
-						Type: "localDirectory",
-						Params: map[string]any{
-							"SourcePath": fmt.Sprintf("/inputs/%s", dealID),
-							"ReadWrite":  true,
-						},
-					},
-					Target: "/inputs",
-				}},
-				ResultPaths: translateOutputSources(job.Spec.Outputs),
+				InputSources: inputSources,
+				ResultPaths:  translateOutputSources(job.Spec.Outputs),
 			},
 		},
 		State:      models.NewJobState(models.JobStateTypePending),

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -31,6 +31,7 @@ type RateLimiterOptions struct {
 
 type StorageOptions struct {
 	MaximumFileInputsMemoryMB int
+	MaximumFileInputsSizeMB   int
 }
 
 type ClientOptions struct {

--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -6,6 +6,7 @@ type ServerOptions struct {
 	Port          int
 	AccessControl AccessControlOptions
 	RateLimiter   RateLimiterOptions
+	Storage       StorageOptions
 }
 
 type AccessControlOptions struct {
@@ -26,6 +27,10 @@ type ValidationToken struct {
 type RateLimiterOptions struct {
 	RequestLimit int
 	WindowLength int
+}
+
+type StorageOptions struct {
+	MaximumFileInputsMemoryMB int
 }
 
 type ClientOptions struct {

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -526,13 +526,13 @@ func PostRequestBufferWithHeaders[ResultType any](
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Debug().Msgf("error reading response body: %s", body)
-		return result, err
+		return result, fmt.Errorf("error reading response body: %s", body)
 	}
 
 	err = json.Unmarshal(body, &result)
 	if err != nil {
 		log.Debug().Msgf("error unmarshaling response body: %s", body)
-		return result, err
+		return result, fmt.Errorf("error unmarshaling response body: %s", body)
 	}
 
 	return result, nil

--- a/pkg/http/utils.go
+++ b/pkg/http/utils.go
@@ -494,6 +494,50 @@ func PostRequestBuffer[ResultType any](
 	return result, nil
 }
 
+func PostRequestBufferWithHeaders[ResultType any](
+	options ClientOptions,
+	path string,
+	headers map[string]string,
+	data *bytes.Buffer,
+) (ResultType, error) {
+	var result ResultType
+	client := newRetryClient()
+	privateKey, err := web3.ParsePrivateKey(options.PrivateKey)
+	if err != nil {
+		return result, err
+	}
+	req, err := retryablehttp.NewRequest("POST", URL(options, path), data)
+	if err != nil {
+		return result, err
+	}
+
+	if err := AddHeaders(req, privateKey, web3.GetAddress(privateKey).String()); err != nil {
+		return result, err
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Debug().Msgf("error reading response body: %s", body)
+		return result, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		log.Debug().Msgf("error unmarshaling response body: %s", body)
+		return result, err
+	}
+
+	return result, nil
+}
+
 func newRetryClient() *retryablehttp.Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 10

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -116,6 +116,7 @@ func (controller *JobCreatorController) AddJobOfferWithFiles(offer data.JobOffer
 	controller.log.Debug("add job offer with files", offer)
 	container, err := controller.solverClient.AddJobOfferWithFiles(offer, inputsPath)
 	if err != nil {
+		controller.log.Error("unable to post job with files", err)
 		return container, err
 	}
 

--- a/pkg/jobcreator/controller.go
+++ b/pkg/jobcreator/controller.go
@@ -112,6 +112,22 @@ func (controller *JobCreatorController) AddJobOffer(offer data.JobOffer) (data.J
 	return container, nil
 }
 
+func (controller *JobCreatorController) AddJobOfferWithFiles(offer data.JobOffer, inputsPath string) (data.JobOfferContainer, error) {
+	controller.log.Debug("add job offer with files", offer)
+	container, err := controller.solverClient.AddJobOfferWithFiles(offer, inputsPath)
+	if err != nil {
+		return container, err
+	}
+
+	// Set the controller's jobID to track this specific job
+	controller.jobID = container.JobOffer.ID
+	controller.log.Debug("Set controller jobID", map[string]any{
+		"jobID": controller.jobID,
+	})
+
+	return container, nil
+}
+
 // SubscribeToJobOfferUpdates subscribes to job offer updates for this controller's job
 // Returns a function that can be called to unsubscribe
 func (controller *JobCreatorController) SubscribeToJobOfferUpdates(sub JobOfferSubscriber) func() {

--- a/pkg/jobcreator/jobcreator.go
+++ b/pkg/jobcreator/jobcreator.go
@@ -30,6 +30,8 @@ type JobCreatorOfferOptions struct {
 	Timeouts data.DealTimeouts
 	// the inputs to the module
 	Inputs map[string]string
+	// The file inputs directory
+	InputsPath string
 	// which mediators and directories this RP will trust
 	Services data.ServiceConfig
 	// which node(s) (if any) to target

--- a/pkg/jobcreator/jobcreator.go
+++ b/pkg/jobcreator/jobcreator.go
@@ -86,6 +86,10 @@ func (jobCreator *BasicJobCreator) AddJobOffer(offer data.JobOffer) (data.JobOff
 	return jobCreator.controller.AddJobOffer(offer)
 }
 
+func (jobCreator *BasicJobCreator) AddJobOfferWithFiles(offer data.JobOffer, inputsPath string) (data.JobOfferContainer, error) {
+	return jobCreator.controller.AddJobOfferWithFiles(offer, inputsPath)
+}
+
 func (jobCreator *BasicJobCreator) SubscribeToJobOfferUpdates(sub JobOfferSubscriber) func() {
 	return jobCreator.controller.SubscribeToJobOfferUpdates(sub)
 }

--- a/pkg/jobcreator/run.go
+++ b/pkg/jobcreator/run.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
+	"github.com/Lilypad-Tech/lilypad/v2/pkg/module"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/system"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/web3"
 	"github.com/rs/zerolog/log"
@@ -85,7 +86,12 @@ func RunJob(
 
 	// Add the job offer
 	span.AddEvent("add_job_offer.start")
-	jobOfferContainer, err := jobCreatorService.AddJobOffer(offer)
+	var jobOfferContainer data.JobOfferContainer
+	if module.HasInputFiles(offer.InputFiles) {
+		jobOfferContainer, err = jobCreatorService.AddJobOfferWithFiles(offer, options.Offer.InputsPath)
+	} else {
+		jobOfferContainer, err = jobCreatorService.AddJobOffer(offer)
+	}
 	if err != nil {
 		jobCreatorService.controller.log.Error("failed to add job offer", err)
 		span.SetStatus(codes.Error, "failed to add job offer")

--- a/pkg/jobcreator/utils.go
+++ b/pkg/jobcreator/utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/module"
+	"github.com/rs/zerolog/log"
 
 	nanoid "github.com/matoous/go-nanoid/v2"
 )
@@ -23,6 +24,10 @@ func getJobOfferFromOptions(options JobCreatorOfferOptions, jobCreatorAddress st
 	if module.HasInputFiles(loadedModule.InputFiles) {
 		err = module.ValidateInputFiles(options.InputsPath, loadedModule.InputFiles)
 		if err != nil {
+			log.Error().Err(err).
+				Str("inputsPath", options.InputsPath).
+				Any("inputFiles", loadedModule.InputFiles).
+				Msg("failed to validate input files")
 			return data.JobOffer{}, fmt.Errorf("error reading input files: %s", err.Error())
 		}
 	}

--- a/pkg/jobcreator/utils.go
+++ b/pkg/jobcreator/utils.go
@@ -20,6 +20,13 @@ func getJobOfferFromOptions(options JobCreatorOfferOptions, jobCreatorAddress st
 		return data.JobOffer{}, fmt.Errorf("error loading module: %s opts=%+v", err.Error(), options)
 	}
 
+	if module.HasInputFiles(loadedModule.InputFiles) {
+		err = module.ValidateInputFiles(options.InputsPath, loadedModule.InputFiles)
+		if err != nil {
+			return data.JobOffer{}, fmt.Errorf("error reading input files: %s", err.Error())
+		}
+	}
+
 	// Generate a nonce to make sure the job offer is unique
 	nonce, err := nanoid.New()
 	if err != nil {
@@ -34,6 +41,7 @@ func getJobOfferFromOptions(options JobCreatorOfferOptions, jobCreatorAddress st
 		Module:     options.Module,
 		Spec:       loadedModule.Machine,
 		Inputs:     options.Inputs,
+		InputFiles: loadedModule.InputFiles,
 		Mode:       options.Mode,
 		Pricing:    options.Pricing,
 		Timeouts:   options.Timeouts,

--- a/pkg/module/utils.go
+++ b/pkg/module/utils.go
@@ -847,6 +847,10 @@ func getHashBasedRepoPath(repoURL, hash string) (string, error) {
 
 // File inputs
 
+func HasInputFiles(inputFiles data.InputFiles) bool {
+	return len(inputFiles.Required) > 0 || len(inputFiles.Optional) > 0
+}
+
 // Check that required files exist and only explicitly defined
 // files are in the target directory
 func ValidateInputFiles(path string, inputFiles data.InputFiles) error {

--- a/pkg/module/utils.go
+++ b/pkg/module/utils.go
@@ -856,9 +856,15 @@ func HasInputFiles(inputFiles data.InputFiles) bool {
 func ValidateInputFiles(path string, inputFiles data.InputFiles) error {
 	allowedFiles := make(map[string]bool)
 	for _, file := range inputFiles.Required {
+		if allowedFiles[file] {
+			return fmt.Errorf("duplicate file %s in input files definition", file)
+		}
 		allowedFiles[file] = true
 	}
 	for _, file := range inputFiles.Optional {
+		if allowedFiles[file] {
+			return fmt.Errorf("duplicate file %s in input files definition", file)
+		}
 		allowedFiles[file] = true
 	}
 

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -42,6 +42,7 @@ func GetDefaultRateLimiterOptions() http.RateLimiterOptions {
 func GetDefaultStorageOptions() http.StorageOptions {
 	return http.StorageOptions{
 		MaximumFileInputsMemoryMB: GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_MEMORY_MB", 20),
+		MaximumFileInputsSizeMB:   GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_SIZE_MB", 10),
 	}
 }
 
@@ -105,6 +106,10 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.Storage.MaximumFileInputsMemoryMB, "server-max-file-inputs-memory-mb", serverOptions.Storage.MaximumFileInputsMemoryMB,
 		`The maxiumum memory used when accepting file inputs to a job (SERVER_MAX_FILE_INPUTS_MEMORY_MB).`,
+	)
+	cmd.PersistentFlags().IntVar(
+		&serverOptions.Storage.MaximumFileInputsSizeMB, "server-max-file-inputs-size-mb", serverOptions.Storage.MaximumFileInputsSizeMB,
+		`The maxiumum file inputs upload size to a job (SERVER_MAX_FILE_INPUTS_SIZE_MB).`,
 	)
 }
 

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -41,7 +41,7 @@ func GetDefaultRateLimiterOptions() http.RateLimiterOptions {
 
 func GetDefaultStorageOptions() http.StorageOptions {
 	return http.StorageOptions{
-		MaximumFileInputsMemoryMB: GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_MEMORY_MB", 20),
+		MaximumFileInputsMemoryMB: GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_MEMORY_MB", 1),
 		MaximumFileInputsSizeMB:   GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_SIZE_MB", 10),
 	}
 }

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -14,6 +14,7 @@ func GetDefaultServerOptions() http.ServerOptions {
 		Port:          GetDefaultServeOptionInt("SERVER_PORT", 8080), //nolint:gomnd
 		AccessControl: GetDefaultAccessControlOptions(),
 		RateLimiter:   GetDefaultRateLimiterOptions(),
+		Storage:       GetDefaultStorageOptions(),
 	}
 }
 
@@ -35,6 +36,12 @@ func GetDefaultRateLimiterOptions() http.RateLimiterOptions {
 	return http.RateLimiterOptions{
 		RequestLimit: GetDefaultServeOptionInt("SERVER_RATE_REQUEST_LIMIT", 5),
 		WindowLength: GetDefaultServeOptionInt("SERVER_RATE_WINDOW_LENGTH", 10),
+	}
+}
+
+func GetDefaultStorageOptions() http.StorageOptions {
+	return http.StorageOptions{
+		MaximumFileInputsMemoryMB: GetDefaultServeOptionInt("SERVER_MAX_FILE_INPUTS_MEMORY_MB", 20),
 	}
 }
 
@@ -94,6 +101,10 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().StringVar(
 		&serverOptions.AccessControl.MinimumVersion, "server-minimum-version", serverOptions.AccessControl.MinimumVersion,
 		`The minimum client version (SERVER_MINIMUM_VERSION).`,
+	)
+	cmd.PersistentFlags().IntVar(
+		&serverOptions.Storage.MaximumFileInputsMemoryMB, "server-max-file-inputs-memory-mb", serverOptions.Storage.MaximumFileInputsMemoryMB,
+		`The maxiumum memory used when accepting file inputs to a job (SERVER_MAX_FILE_INPUTS_MEMORY_MB).`,
 	)
 }
 

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -480,6 +480,28 @@ func (controller *ResourceProviderController) runJob(ctx context.Context, deal d
 		controller.log.Info("module loaded", loadedModule)
 		span.AddEvent("module.loaded")
 
+		if module.HasInputFiles(loadedModule.InputFiles) {
+			controller.log.Info("downloading file inputs", loadedModule.InputFiles)
+			span.AddEvent("solver.files.download")
+			dirPath := solver.GetInputsFilePath(deal.Deal.ID)
+			err = controller.solverClient.DownloadInputFiles(deal.ID, dirPath)
+			if err != nil {
+				controller.log.Error("download input files failed", err)
+				span.SetStatus(codes.Error, "download input files failed")
+				span.RecordError(err)
+				return fmt.Errorf("error downloading input files: %s", err.Error())
+			}
+
+			err = module.ValidateInputFiles(dirPath, deal.Deal.JobOffer.InputFiles)
+			if err != nil {
+				controller.log.Error("unexpected input files", err)
+				span.SetStatus(codes.Error, "input files validation failed")
+				span.RecordError(err)
+				return fmt.Errorf("error validating downloaded input files: %s", err.Error())
+			}
+			span.AddEvent("solver.files.downloaded")
+		}
+
 		span.AddEvent("executor.job.start")
 		executorResult, err := controller.executor.RunJob(deal, *loadedModule)
 		if err != nil {

--- a/pkg/resourceprovider/controller.go
+++ b/pkg/resourceprovider/controller.go
@@ -471,17 +471,17 @@ func (controller *ResourceProviderController) runJob(ctx context.Context, deal d
 	err := func() error {
 		controller.log.Info("loading module", "")
 		span.AddEvent("module.load")
-		module, err := module.LoadModule(deal.Deal.JobOffer.Module, deal.Deal.JobOffer.Inputs)
+		loadedModule, err := module.LoadModule(deal.Deal.JobOffer.Module, deal.Deal.JobOffer.Inputs)
 		if err != nil {
 			span.SetStatus(codes.Error, "load module failed")
 			span.RecordError(err)
 			return fmt.Errorf("error loading module: %s", err.Error())
 		}
-		controller.log.Info("module loaded", module)
+		controller.log.Info("module loaded", loadedModule)
 		span.AddEvent("module.loaded")
 
 		span.AddEvent("executor.job.start")
-		executorResult, err := controller.executor.RunJob(deal, *module)
+		executorResult, err := controller.executor.RunJob(deal, *loadedModule)
 		if err != nil {
 			controller.log.Error("error running job", err)
 			span.SetStatus(codes.Error, "job execution failed")

--- a/pkg/solver/client.go
+++ b/pkg/solver/client.go
@@ -201,6 +201,14 @@ func (client *SolverClient) UploadResultFiles(id string, localPath string) (data
 	return http.PostRequestBuffer[data.Result](client.options, fmt.Sprintf("/deals/%s/files", id), buf)
 }
 
+func (client *SolverClient) DownloadInputFiles(id string, localPath string) error {
+	buf, err := http.GetRequestBuffer(client.options, fmt.Sprintf("/deals/%s/input_files", id), map[string]string{})
+	if err != nil {
+		return err
+	}
+	return system.ExpandTarBuffer(buf, localPath)
+}
+
 func (client *SolverClient) DownloadResultFiles(id string, localPath string) error {
 	buf, err := http.GetRequestBuffer(client.options, fmt.Sprintf("/deals/%s/files", id), map[string]string{})
 	if err != nil {

--- a/pkg/solver/client.go
+++ b/pkg/solver/client.go
@@ -1,9 +1,12 @@
 package solver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
 
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/http"
@@ -122,6 +125,52 @@ func (client *SolverClient) GetDealsWithFilter(query store.GetDealsQuery, filter
 
 func (client *SolverClient) AddJobOffer(jobOffer data.JobOffer) (data.JobOfferContainer, error) {
 	return http.PostRequest[data.JobOffer, data.JobOfferContainer](client.options, "/job_offers", jobOffer)
+}
+
+func (client *SolverClient) AddJobOfferWithFiles(jobOffer data.JobOffer, inputsPath string) (data.JobOfferContainer, error) {
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	// Add job offer part
+	jobOfferPart, err := writer.CreateFormFile("job_offer.json", "job_offer.json")
+	if err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error creating job offer part: %w", err)
+	}
+	jobOfferJson, err := json.Marshal(jobOffer)
+	if err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error marshaling job offer: %w", err)
+	}
+	if _, err := jobOfferPart.Write([]byte(jobOfferJson)); err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error writing job offer part: %w", err)
+	}
+
+	// Add input files part
+	inputBuf, err := system.GetTarBuffer(inputsPath)
+	if err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error creating inputs file tar buffer: %w", err)
+	}
+	inputPart, err := writer.CreateFormFile("inputs.tar", "inputs.tar")
+	if err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error creating inputs file part: %w", err)
+	}
+	if _, err := io.Copy(inputPart, inputBuf); err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error writing inputs file part: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return data.JobOfferContainer{}, fmt.Errorf("error closing multipart writer: %w", err)
+	}
+
+	// Add content type header
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+
+	return http.PostRequestBufferWithHeaders[data.JobOfferContainer](
+		client.options,
+		"/job_offers/with_files",
+		headers,
+		&requestBody,
+	)
 }
 
 func (client *SolverClient) AddResourceOffer(resourceOffer data.ResourceOffer) (data.ResourceOfferContainer, error) {

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -437,7 +437,7 @@ func (server *solverServer) addJobOfferWithFiles(res corehttp.ResponseWriter, re
 				Str("address", jobOffer.JobCreator).
 				Str("version", versionHeader).
 				Str("minVersion", minVersion).
-				Msg("job offer rejected because job creator is running an unsupported version")
+				Msg("job offer with files rejected because job creator is running an unsupported version")
 			corehttp.Error(res,
 				fmt.Sprintf("Please update to minimum supported version %s or newer: https://github.com/Lilypad-Tech/lilypad/releases", minVersion),
 				corehttp.StatusForbidden)

--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -390,8 +390,8 @@ func (server *solverServer) addJobOfferWithFiles(res corehttp.ResponseWriter, re
 
 	// Set a maximum size for the entire request body
 	// This includes the job offer, which only accounts for a small portion of the request body
-	maxRequestSize := int64(server.options.Storage.MaximumFileInputsSizeMB << 20)
-	req.Body = corehttp.MaxBytesReader(res, req.Body, maxRequestSize)
+	maxRequestSizeBytes := int64(server.options.Storage.MaximumFileInputsSizeMB << 20)
+	req.Body = corehttp.MaxBytesReader(res, req.Body, maxRequestSizeBytes)
 
 	// Parse the multipart form with max memory size
 	err = req.ParseMultipartForm(int64(server.options.Storage.MaximumFileInputsMemoryMB << 20))

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -50,7 +50,7 @@ func NewSolver(
 	if err != nil {
 		return nil, err
 	}
-	server, err := NewSolverServer(options.Server, controller, store, stats, versionConfig, options.Services)
+	server, err := NewSolverServer(options.Server, controller, store, stats, versionConfig, options.Services, meter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/solver/utils.go
+++ b/pkg/solver/utils.go
@@ -9,6 +9,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Resource provider storage for expanded job inputs
+const INPUTS_DIR = "job-inputs"
+
 // Solver storage for tar input files
 const INPUT_ARCHIVES_DIR = "job-input-archives"
 const FILES_DIR = "job-files"
@@ -59,12 +62,20 @@ func GetInputArchivesPath(id string) string {
 	return system.GetDataDir(filepath.Join(INPUT_ARCHIVES_DIR, id))
 }
 
+func GetInputsFilePath(id string) string {
+	return system.GetDataDir(filepath.Join(INPUTS_DIR, id))
+}
+
 func GetDealsFilePath(id string) string {
 	return system.GetDataDir(filepath.Join(FILES_DIR, id))
 }
 
 func EnsureInputsArchivePath(id string) (string, error) {
 	return system.EnsureDataDir(filepath.Join(INPUT_ARCHIVES_DIR, id))
+}
+
+func EnsureInputsFilePath(id string) (string, error) {
+	return system.EnsureDataDir(filepath.Join(INPUTS_DIR, id))
 }
 
 func EnsureDealsFilePath(id string) (string, error) {

--- a/pkg/solver/utils.go
+++ b/pkg/solver/utils.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Solver storage for tar input files
+const INPUT_ARCHIVES_DIR = "job-input-archives"
 const FILES_DIR = "job-files"
 const DOWNLOADS_DIR = "downloaded-files"
 
@@ -53,8 +55,16 @@ func ServiceLogSolverEvent(service system.Service, ev SolverEvent) {
 	LogSolverEvent(system.GetServiceBadge(service), ev)
 }
 
+func GetInputArchivesPath(id string) string {
+	return system.GetDataDir(filepath.Join(INPUT_ARCHIVES_DIR, id))
+}
+
 func GetDealsFilePath(id string) string {
 	return system.GetDataDir(filepath.Join(FILES_DIR, id))
+}
+
+func EnsureInputsArchivePath(id string) (string, error) {
+	return system.EnsureDataDir(filepath.Join(INPUT_ARCHIVES_DIR, id))
 }
 
 func EnsureDealsFilePath(id string) (string, error) {


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add `inputFiles` field to module spec
- [x] Add `inputFiles` to job creator
  - [x] Add `INPUTS_PATH` config to job creator options
  - [x] Add `inputFiles` to CLI run command
  - [x] Check files in input path match requested `inputFiles`
- [x] Add solver support for job offers with file inputs
  - [x] Add `SERVER_MAX_FILE_INPUTS_MEMORY_MB` to set max memory consumed when processing input files
  - [x] Add `SERVER_MAX_FILE_INPUTS_SIZE_MB` to set max file upload size
  - [x] Add post job offer with files endpoint and handler
  - [x] Add get download inputs file endpoint and handler
  - [x] Add metric to track file input sizes
- [x] Add CLI run command post job offer with files
  - [x] Add solver client and job creator methods to call when `inputFiles` is non-empty 
  - [x]  Add `PostRequestBufferWithHeaders` helper
- [x] Add resource provider support for jobs with file inputs
  - [x] Add download files when `inputFiles`
  - [x] Add Bacalhau support

This pull request adds file intputs to jobs. We want to extend the capability of jobs by allowing audio, video, and other file inputs.

We have also updated the integration tests to create isolated data directories in the GH actions `workspace` for each service.

### Task/Issue reference

Closes: #572 

### Test plan

We have created an example module to demostrate the file inputs functionality: https://github.com/Lilypad-Tech/lilypad-concat-files-module

Rebuild the base services to include the new Bacalhau input sources permission.

```sh
./stack compose-build
```

Create a local `inputs` directory and add `one.txt` and `two.txt` files with some text content in them.

Start the stack. Run a job using the example module.

```sh
./stack run github.com/Lilypad-Tech/lilypad-concat-files-module:main --inputs-path=./inputs
```

Now add `three.txt` and `four.txt` text files and run another job. This confirms optional files will be included and concatenated into the output.

Run another job that places a separator between each of the text file inputs.

```sh
./stack run github.com/Lilypad-Tech/lilypad-concat-files-module:main --inputs-path=./inputs -i Separator="=========="
```

Lastly, check that the max file input size config works by stopping the solver, and running again with a 0MB max input file size.

```sh
./stack solver --server-max-file-inputs-size-mb 0
```

### Details

#### Modules

We have added an `inputFiles` field to the module spec. This field declares required and optional input files. For example:

```json
"inputFiles": {
  "required": ["one.txt", "two.txt"],
  "optional": ["three.txt", "four.txt"]
}
```

The `one.txt` and `two.txt` files are required, and `three.txt` and `four.txt` are optional. No other files are allowed.

#### Job creator

We have added file inputs support to the CLI run command. The CLI run command checks for required files and ensures only explicitly declared files are present. All files must be in a single directory without subdirectories.

#### Solver

The solver has two new endpoints:

- `/job_offers/with_files`. Accepts a `multipart/form-data` request with a job offer and a tar archive with input files.
- `/deals/{id}/input_files`. Accepts a request to download the input files tar archive associated with a deal `id` from a resource provider.

A `/job_offers/with_files` route has been added for job creators and Anura. The resource provider is authenticated by signature before they are allowed to download input files.

Uploaded file inputs are stored in a `<DATA_DIR>/job-input-archives/<job-offer-id>` directory (defaults to `/tmp/lilypad/data/job-input-archives/<job-offer-id>`)

#### Resource provider

The resource provider checks the job offer to determine if a job has file inputs. If it does, it requests them from the solver before running the job.

Downloaded file inputs extracted from the tar archive and stored in a `<DATA_DIR>/job-inputs/<deal-id>` directory (defaults to `/tmp/lilypad/data/job-inputs/deal-id>`)

Bacalhau is granted access to the `job-inputs` directory so that it can access file inputs. Note that the current implementation will work for Docker RPs, but may take some extra work for others to configure.

#### Configs

We have added a new `INPUTS_PATH` config to the CLI run command options. An `inputs` directory can be set with a CLI option or an environment variable:

```sh
./stack run github.com/Lilypad-Tech/lilypad-concat-files-module:main --inputs-path=./inputs
INPUTS_PATH=./inputs ./stack run github.com/Lilypad-Tech/lilypad-concat-files-module:main
```

We have also added `SERVER_MAX_FILE_INPUTS_MEMORY_MB` and `SERVER_MAX_FILE_INPUTS_SIZE_MB` configs to the solver server. 

`SERVER_MAX_FILE_INPUTS_MEMORY_MB` sets how much memory is used when accepting file inputs. Larger file inputs can be sent, but anything in excess of the memory max is temporarily stored on disk.

```sh
./stack solver --server-max-file-inputs-memory-mb 10
SERVER_MAX_FILE_INPUTS_MEMORY_MB=10 ./stack solver
```

`SERVER_MAX_FILE_INPUTS_SIZE_MB` sets the maxiumum uploaded input files size.

```sh
./stack solver --server-max-file-inputs-size-mb 10
SERVER_MAX_FILE_INPUTS_SIZE_MB=10 ./stack solver
```

#### Metrics

We have added metrics to track job offers with and without file inputs, and the size of file inputs when present. In our Grafana dashboard, we plan to display percent of jobs with file inputs and average file inputs size:

![CleanShot 2025-05-05 at 14 36 58@2x](https://github.com/user-attachments/assets/2fea0d62-572e-405a-8089-b3d81fa381c0)


### Related issues or PRs

Design doc: https://www.notion.so/lilypadnetwork/File-Inputs-1d1155da99b5806ea3c8fa0f7788e7ae
Observability PR: https://github.com/Lilypad-Tech/observability/pull/33
