### PR TITLE
feat: Add job offer max capacity check

### DIFF
--- a/pkg/http/types.go
+++ b/pkg/http/types.go
@@ -18,6 +18,7 @@ type AccessControlOptions struct {
 	OfferTimestampDiffSeconds       int
 	EnableVersionCheck              bool
 	MinimumVersion                  string
+	MaximumJobOfferCapacity         int
 }
 
 type ValidationToken struct {

--- a/pkg/options/server.go
+++ b/pkg/options/server.go
@@ -29,6 +29,7 @@ func GetDefaultAccessControlOptions() http.AccessControlOptions {
 		OfferTimestampDiffSeconds:       GetDefaultServeOptionInt("SERVER_OFFER_TIMESTAMP_DIFF_SECONDS", 30),
 		EnableVersionCheck:              GetDefaultServeOptionBool("SERVER_ENABLE_VERSION_CHECK", true),
 		MinimumVersion:                  GetDefaultServeOptionString("SERVER_MINIMUM_VERSION", ""),
+		MaximumJobOfferCapacity:         GetDefaultServeOptionInt("SERVER_MAX_JOB_OFFER_CAPACITY", 1000),
 	}
 }
 
@@ -102,6 +103,10 @@ func AddServerCliFlags(cmd *cobra.Command, serverOptions *http.ServerOptions) {
 	cmd.PersistentFlags().StringVar(
 		&serverOptions.AccessControl.MinimumVersion, "server-minimum-version", serverOptions.AccessControl.MinimumVersion,
 		`The minimum client version (SERVER_MINIMUM_VERSION).`,
+	)
+	cmd.PersistentFlags().IntVar(
+		&serverOptions.AccessControl.MaximumJobOfferCapacity, "server-max-job-offer-capacity", serverOptions.AccessControl.MaximumJobOfferCapacity,
+		`The maximum unmatched job offers before new offers are rejected (SERVER_MAX_JOB_OFFER_CAPACITY).`,
 	)
 	cmd.PersistentFlags().IntVar(
 		&serverOptions.Storage.MaximumFileInputsMemoryMB, "server-max-file-inputs-memory-mb", serverOptions.Storage.MaximumFileInputsMemoryMB,


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Add max job offer capacity check
  - [x] Add `SERVER_MAX_JOB_OFFER_CAPACITY` config
  - [x] Add capacity check on add job offer handlers 

The pull request adds a max job offer capacity check to the solver server. We want to control the job offer queue size to ensure smooth operations.

Note that this work may be superceded by the match timeouts in #560, which will time out offers much more quickly than we currently do.

### Test plan

Start the base services, and start the solver with a max capacity of `-1`:

```
SERVER_MAX_JOB_OFFER_CAPACITY=-1 ./stack solver
```

Start a resource provider and attempt to run a job. The job offer should be rejected with a "network busy" message after a few retries.

Restart the solver with a more realistic capacity of `100`:

```sh
SERVER_MAX_JOB_OFFER_CAPACITY=100 ./stack solver
```

Run a job. This one should go through.

### Details 

We have added a new `SERVER_MAX_JOB_OFFER_CAPACITY` config in this PR. Configure the solver with an environment variable or CLI option:

```sh
SERVER_MAX_JOB_OFFER_CAPACITY=100 ./stack solver
./stack solver --server-max-job-offer-capacity 100
```
