### PR TITLE
fix: Exclude cancelled jobs from max job offer capacity

### DIFF
--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -346,6 +346,7 @@ func (server *solverServer) getResult(res corehttp.ResponseWriter, req *corehttp
 func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.ResponseWriter, req *corehttp.Request) (*data.JobOfferContainer, error) {
 	unmatchedOffers, err := server.store.GetJobOffers(store.GetJobOffersQuery{
 		NotMatched: true,
+		Cancelled:  system.BoolPointer(false),
 	})
 	if len(unmatchedOffers) > server.options.AccessControl.MaximumJobOfferCapacity {
 		server.log.Warn().Err(err).Msgf("job offer received while at max job offer capacity")
@@ -399,6 +400,7 @@ func (server *solverServer) addJobOffer(jobOffer data.JobOffer, res corehttp.Res
 func (server *solverServer) addJobOfferWithFiles(res corehttp.ResponseWriter, req *corehttp.Request) {
 	unmatchedOffers, err := server.store.GetJobOffers(store.GetJobOffersQuery{
 		NotMatched: true,
+		Cancelled:  system.BoolPointer(false),
 	})
 	if len(unmatchedOffers) > server.options.AccessControl.MaximumJobOfferCapacity {
 		server.log.Warn().Err(err).Msgf("job offer received while at max job offer capacity")


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Exclude cancelled jobs from max job offer capacity

This pull request updates the max job offer capacity check introduced in #576. We need to exclude cancelled jobs that were never matched from capacity count.

### Task/Issue reference

Updates: #576

### Test plan

Drop all job offers from your local database. Now, add a job offer that will timeout without a match.

Start the base services. Start the solver with:

```sh
JOB_TIMEOUT_SECONDS=1 st sol ./stack solver
```

Do _not_ start a resource provider, but run a job. This should timeout quickly. Check the DB, and you should have a job offer in cancelled state that is unmatched (`deal_id` is empty string).

Stop the solver, and restart with:

```sh
SERVER_MAX_JOB_OFFER_CAPACITY=-1 ./stack solver
```

Start a resource provider and run a job. The job should fail with a "network busy" error message.

Check the solver logs for a message like:

```
+++ unmatched offers: []
```

This demonstrates that the cancelled, but unmatched, job offer was not included in the queried `unmatched offers`. 

The log was added as a temporary commit (d3100e3) which we will remove before merging.