### PR TITLE
fix: version ARGs for RP Dockerfile

### DIFF
--- a/docker/resource-provider/Dockerfile
+++ b/docker/resource-provider/Dockerfile
@@ -9,6 +9,9 @@ COPY . .
 
 FROM nvidia/cuda:12.0.1-cudnn8-devel-ubuntu22.04 AS build-gpu
 WORKDIR /usr/src/app
+ARG VERSION
+ARG COMMIT_SHA
+
 COPY --from=base /usr/src/app .
 COPY --from=base /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -17,6 +20,9 @@ RUN go build -v -tags cuda -ldflags="-X 'github.com/Lilypad-Tech/lilypad/v2/pkg/
 ENV DISABLE_POW=false
 
 FROM base AS build-cpu
+ARG VERSION
+ARG COMMIT_SHA
+
 RUN go build -v -ldflags="-X 'github.com/Lilypad-Tech/lilypad/v2/pkg/system.Version=${VERSION}' -X 'github.com/Lilypad-Tech/lilypad/v2/pkg/system.CommitSHA=${COMMIT_SHA}'"
 ENV DISABLE_POW=true
 


### PR DESCRIPTION
### Summary

This PR properly scopes the `VERSION` and `COMMIT_SHA` args so that docker builds of the RP properly report this information. These values are set in the `release_docker.yml` workflow: https://github.com/Lilypad-Tech/lilypad/blob/main/.github/workflows/release_docker.yml#L44-L46 however the args weren't properly scoped to the actual build stages in the Dockerfile.