### PR TITLE
perf: Remove supported modules check from solver matching algorithm

### DIFF
--- a/pkg/options/resource-provider.go
+++ b/pkg/options/resource-provider.go
@@ -147,6 +147,10 @@ func CheckResourceProviderOfferOptions(options resourceprovider.ResourceProvider
 		return fmt.Errorf("OFFER_RAM cannot be zero")
 	}
 
+	if len(options.Modules) > 0 {
+		return fmt.Errorf("OFFER_MODULES module list is not currently supported")
+	}
+
 	return nil
 }
 

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -144,7 +144,6 @@ func (result marketPriceUnavailable) attributes() []attribute.KeyValue {
 type priceMismatch struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer
-	moduleID      string
 }
 
 func (_ priceMismatch) matched() bool { return false }
@@ -153,18 +152,15 @@ func (_ priceMismatch) message() string {
 }
 func (result priceMismatch) attributes() []attribute.KeyValue {
 	// If the module instruction price is not specified, this lookup will use the zero-value of 0
-	moduleInstructionPrice := result.resourceOffer.ModulePricing[result.moduleID].InstructionPrice
 
 	return []attribute.KeyValue{
 		attribute.String("match_result", fmt.Sprintf("%T", result)),
 		attribute.Bool("match_result.matched", result.matched()),
 		attribute.String("match_result.message", result.message()),
 		attribute.Int("match_result.job_offer.pricing.instruction_price", int(result.jobOffer.Pricing.InstructionPrice)),
-		attribute.Int("match_result.resource_offer.module_pricing.instruction_price", int(moduleInstructionPrice)),
 		attribute.Int("match_result.resource_offer.default_pricing.instruction_price", int(result.resourceOffer.DefaultPricing.InstructionPrice)),
 		attribute.String("match_result.job_offer.mode", string(result.jobOffer.Mode)),
 		attribute.String("match_result.resource_offer.mode", string(result.resourceOffer.Mode)),
-		attribute.String("match_result.module_id", result.moduleID),
 		attribute.StringSlice("match_result.resource_offer.modules", result.resourceOffer.Modules),
 		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
 		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
@@ -273,7 +269,6 @@ func matchOffers(
 			return priceMismatch{
 				jobOffer:      jobOffer,
 				resourceOffer: resourceOffer,
-				moduleID:      moduleID,
 			}
 		}
 	}

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -300,35 +300,6 @@ func matchOffers(
 		}
 	}
 
-	moduleID, err := data.GetModuleID(jobOffer.Module)
-	if err != nil {
-		return moduleIDError{
-			jobOffer:      jobOffer,
-			resourceOffer: resourceOffer,
-			err:           err,
-		}
-	}
-
-	// if the resource provider has specified modules then check them
-	if len(resourceOffer.Modules) > 0 {
-		// if the resourceOffer.Modules array does not contain the moduleID then we don't match
-		hasModule := false
-		for _, module := range resourceOffer.Modules {
-			if module == moduleID {
-				hasModule = true
-				break
-			}
-		}
-
-		if !hasModule {
-			return moduleMismatch{
-				jobOffer:      jobOffer,
-				resourceOffer: resourceOffer,
-				moduleID:      moduleID,
-			}
-		}
-	}
-
 	// we don't currently support market priced resource offers
 	if resourceOffer.Mode == data.MarketPrice {
 		return marketPriceUnavailable{

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -125,25 +125,6 @@ func (result diskSpaceMismatch) attributes() []attribute.KeyValue {
 	}
 }
 
-type moduleIDError struct {
-	resourceOffer data.ResourceOffer
-	jobOffer      data.JobOffer
-	err           error
-}
-
-func (_ moduleIDError) matched() bool   { return false }
-func (_ moduleIDError) message() string { return "error computing module ID" }
-func (result moduleIDError) attributes() []attribute.KeyValue {
-	return []attribute.KeyValue{
-		attribute.String("match_result", fmt.Sprintf("%T", result)),
-		attribute.Bool("match_result.matched", result.matched()),
-		attribute.String("match_result.message", result.message()),
-		attribute.String("match_result.err", result.err.Error()),
-		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
-		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
-	}
-}
-
 type moduleMismatch struct {
 	resourceOffer data.ResourceOffer
 	jobOffer      data.JobOffer
@@ -377,12 +358,6 @@ func logMatch(result matchResult, log *zerolog.Logger) {
 			Str("job offer", r.jobOffer.ID).
 			Int("resource RAM", r.resourceOffer.Spec.RAM).
 			Int("job RAM", r.jobOffer.Spec.RAM).
-			Msg(r.message())
-	case moduleIDError:
-		log.Error().
-			Str("resource offer", r.resourceOffer.ID).
-			Str("job offer", r.jobOffer.ID).
-			Err(r.err).
 			Msg(r.message())
 	case moduleMismatch:
 		log.Trace().

--- a/pkg/solver/matcher/match.go
+++ b/pkg/solver/matcher/match.go
@@ -2,7 +2,6 @@ package matcher
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
 	"github.com/rs/zerolog"
@@ -122,26 +121,6 @@ func (result diskSpaceMismatch) attributes() []attribute.KeyValue {
 		attribute.String("match_result.message", result.message()),
 		attribute.Int("match_result.job_offer.spec.disk", result.jobOffer.Spec.Disk),
 		attribute.Int("match_result.resource_offer.spec.disk", result.resourceOffer.Spec.Disk),
-	}
-}
-
-type moduleMismatch struct {
-	resourceOffer data.ResourceOffer
-	jobOffer      data.JobOffer
-	moduleID      string
-}
-
-func (_ moduleMismatch) matched() bool   { return false }
-func (_ moduleMismatch) message() string { return "resource provider does not provide module" }
-func (result moduleMismatch) attributes() []attribute.KeyValue {
-	return []attribute.KeyValue{
-		attribute.String("match_result", fmt.Sprintf("%T", result)),
-		attribute.Bool("match_result.matched", result.matched()),
-		attribute.String("match_result.message", result.message()),
-		attribute.String("match_result.module_id", result.moduleID),
-		attribute.StringSlice("match_result.resource_offer.modules", result.resourceOffer.Modules),
-		attribute.String("match_result.job_offer.module.repo", result.jobOffer.Module.Repo),
-		attribute.String("match_result.job_offer.module.hash", result.jobOffer.Module.Hash),
 	}
 }
 
@@ -358,12 +337,6 @@ func logMatch(result matchResult, log *zerolog.Logger) {
 			Str("job offer", r.jobOffer.ID).
 			Int("resource RAM", r.resourceOffer.Spec.RAM).
 			Int("job RAM", r.jobOffer.Spec.RAM).
-			Msg(r.message())
-	case moduleMismatch:
-		log.Trace().
-			Str("resource offer", r.resourceOffer.ID).
-			Str("job offer", r.jobOffer.ID).
-			Str("modules", strings.Join(r.resourceOffer.Modules, ", ")).
 			Msg(r.message())
 	case marketPriceUnavailable:
 		log.Trace().

--- a/pkg/solver/matcher/testing.go
+++ b/pkg/solver/matcher/testing.go
@@ -50,21 +50,6 @@ func getMatchTestCases() []matchTestCase {
 		Services: baseServices,
 	}
 
-	// Module configs
-	cowsayModuleConfig := data.ModuleConfig{
-		Name: "cowsay",
-		Repo: "https://github.com/Lilypad-Tech/lilypad-module-cowsay",
-		Hash: "v0.0.4",
-		Path: "/lilypad_module.json.tmpl",
-	}
-
-	lilysayModuleConfig := data.ModuleConfig{
-		Name: "lilysay",
-		Repo: "https://github.com/Lilypad-Tech/lilypad-module-lilysay",
-		Hash: "v0.5.2",
-		Path: "/lilypad_module.json.tmpl",
-	}
-
 	testCases := []matchTestCase{
 		// Matching cases
 		{
@@ -128,22 +113,6 @@ func getMatchTestCases() []matchTestCase {
 			jobOffer: func() data.JobOffer {
 				j := baseJobOffer
 				j.Spec.Disk = 0 // zero-value
-				return j
-			}(),
-			expectedResult: "*matcher.offersMatched",
-			shouldMatch:    true,
-		},
-		{
-			name: "Resource provider supports module",
-			resourceOffer: func() data.ResourceOffer {
-				r := baseResourceOffer
-				moduleID, _ := data.GetModuleID(cowsayModuleConfig)
-				r.Modules = []string{moduleID}
-				return r
-			}(),
-			jobOffer: func() data.JobOffer {
-				j := baseJobOffer
-				j.Module = cowsayModuleConfig
 				return j
 			}(),
 			expectedResult: "*matcher.offersMatched",
@@ -250,22 +219,6 @@ func getMatchTestCases() []matchTestCase {
 				return j
 			}(),
 			expectedResult: "*matcher.diskSpaceMismatch",
-			shouldMatch:    false,
-		},
-		{
-			name: "Resource provider does not support module",
-			resourceOffer: func() data.ResourceOffer {
-				r := baseResourceOffer
-				moduleID, _ := data.GetModuleID(cowsayModuleConfig)
-				r.Modules = []string{moduleID}
-				return r
-			}(),
-			jobOffer: func() data.JobOffer {
-				j := baseJobOffer
-				j.Module = lilysayModuleConfig
-				return j
-			}(),
-			expectedResult: "*matcher.moduleMismatch",
 			shouldMatch:    false,
 		},
 		{


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Remove supported modules check from matching algo
  - [x] Remove `moduleIDError` match result
  - [x] Remove `moduleMismatch` match result
  - [x] Remove module ID dependeny from `priceMismatch` match result
  - [x] Update tests to remove supported module test cases
- [x] Prevent resource providers from using `OFFER_MODULES` config 

The solver matching algorithm is underperforming and we want it to run faster.

### Test plan

Run the benchmarks on `main`:

```sh
./stack benchmarks-solver
```

Run them again on this branch to observe the improved results.

Start a resource provider with a module list:

```
./stack resource-provider --offer-modules "QmVvTRUBJiiUmEp3P1ubU3djgsbABdF3xswouVpM21rCto"
OFFER_MODULES=QmVvTRUBJiiUmEp3P1ubU3djgsbABdF3xswouVpM21rCto ./stack resource-provider
```

Both commands should fail with a `Error: OFFER_MODULES module list is not currently supported` error message.

Lastly, start the stack. Run a few jobs. Make sure everything generally works.

### Details

The resource offer has a list of supported modules that must be expressed as CIDs. As we have discussed, this mechanism is inconvenient for resource providers, and we could use the module identifier instead: https://github.com/Lilypad-Tech/lilypad/issues/493

We are not aware of any resource providers that use the module list mechanism, so we have disabled it and will revisit in future work.

The solver matching algorithm compares the requested job offer module against the resource provider module list. The job offer does not have a module CID, so we compute it on the fly. This check is the main bottleneck in the solver matching algorithm, and because it is unused, we remove it in this pull request.