### PR TITLE
chore: Increase test solver wait time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           DATA_DIR: ${{ github.workspace }}/sol
         run: |
           ./stack solver --disable-telemetry=true --api-host="" > solver.log &
-          sleep 20
+          sleep 30
 
       - name: Run solver integration tests
         run: ./stack integration-tests-solver


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Increase the time we wait for the solver before integration tests

We ran into failing test runs where the solver was not booting in time for the integration test, for example: https://github.com/Lilypad-Tech/lilypad/actions/runs/15285727592/job/42995342989