### PR TITLE
fix: add GPU access to Bacalhau in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,13 @@ services:
     volumes:
       - bacalhau-data:/root/.bacalhau
       - /tmp/lilypad/data/job-inputs/:/inputs
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
   resource-provider:
     image: ghcr.io/lilypad-tech/resource-provider:latest
     container_name: resource-provider


### PR DESCRIPTION

### Summary

This pull request makes the following changes:

- [x] Added GPU reservation params to the Bacalhau service in docker-compose.yml, matching resource-provider configuration. 

The existing docker-compose.yml only provided GPU access to the resource-provider service, while the Bacalhau compute node itself couldn't _always_ detect available GPUs. This was occasionally evident by GPU enabled RP's showing "0/0" GPUs within the RP's resourceOffer. 

This modification will fix that. 

### Task/Issue reference

Jaco's a100 node showing as only a compute node. 

### Test plan

Startup a GPU enabled RP by using this docker compose file. 
