### PR TITLE
feat: adds index on MatchDecision table for faster lookup

### DIFF
--- a/pkg/solver/store/db/models.go
+++ b/pkg/solver/store/db/models.go
@@ -43,8 +43,8 @@ type Result struct {
 
 type MatchDecision struct {
 	gorm.Model    `gorm:"type:timestamp(3) with time zone"`
-	ResourceOffer string `gorm:"primaryKey"`
-	JobOffer      string `gorm:"primaryKey"`
+	ResourceOffer string `gorm:"primaryKey;index:idx_resource_offer_job_offer,priority:1"`
+	JobOffer      string `gorm:"primaryKey;index:idx_resource_offer_job_offer,priority:2"`
 	Attributes    datatypes.JSONType[data.MatchDecision]
 }
 


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Adds an index on the MatchDecision table to make lookups in the match algo faster

Explain the motivation for making these changes. Does this pull request implement a feature or fix a bug? Is it a docs change or a typo fix?

This is the first of a series of improvements to be made in the solver algorithm in an effort to improve its performance as discussed in the following [issue](https://github.com/Lilypad-Tech/lilypad/issues/503)

### Task/Issue reference

Closes: add_link_here

### Test plan

Please describe how reviewers can test the changes in this pull request. If the test plan is challenging to explain in text alone, a short video demonstration may be included.

1. Start up the stack as normal
2. Using your DB tool of choice, connect to your local postgres instance and find the`match_decisions` table, click on indexes and confirm `idx_resource_offer_job_offer` exists
<img width="306" alt="image" src="https://github.com/user-attachments/assets/56cf8314-baf4-4f30-b3f0-5120e2395c2b" />


### Details (optional)

Add any additional details that will help to review this pull request.

### Related issues or PRs (optional)

Add any related issues or PRs.
