### PR TITLE
perf: bulk write match decisions

### DIFF
--- a/pkg/solver/store/db/models.go
+++ b/pkg/solver/store/db/models.go
@@ -11,7 +11,7 @@ type JobOffer struct {
 	CID        string `gorm:"index"`
 	JobCreator string `gorm:"index"`
 	DealID     string `gorm:"index"`
-	State      uint8
+	State      uint8  `gorm:"index"`
 	Attributes datatypes.JSONType[data.JobOfferContainer]
 }
 

--- a/pkg/solver/store/memory/store.go
+++ b/pkg/solver/store/memory/store.go
@@ -82,6 +82,21 @@ func (s *SolverStoreMemory) AddMatchDecision(resourceOffer string, jobOffer stri
 	return decision, nil
 }
 
+/*
+*
+Note: This is being added here as a formaility to statisfy the interface definition. Since this is an in-memory map we don't have the bottle neck of database writes, thus can loop through
+and add the records one by one
+*/
+func (s *SolverStoreMemory) AddBulkMatchDecisions(records []data.MatchDecision) error {
+	for _, record := range records {
+		_, err := s.AddMatchDecision(record.ResourceOffer, record.JobOffer, record.Deal, record.Result)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (store *SolverStoreMemory) AddAllowedResourceProvider(resourceProvider string) (string, error) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()

--- a/pkg/solver/store/store.go
+++ b/pkg/solver/store/store.go
@@ -72,6 +72,7 @@ type SolverStore interface {
 	AddDeal(deal data.DealContainer) (*data.DealContainer, error)
 	AddResult(result data.Result) (*data.Result, error)
 	AddMatchDecision(resourceOffer string, jobOffer string, deal string, result bool) (*data.MatchDecision, error)
+	AddBulkMatchDecisions(records []data.MatchDecision) error
 	AddAllowedResourceProvider(resourceProvider string) (string, error)
 	GetJobOffers(query GetJobOffersQuery) ([]data.JobOfferContainer, error)
 	GetResourceOffers(query GetResourceOffersQuery) ([]data.ResourceOfferContainer, error)


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- [x] Makes the MatchDecision write operation a bulk one in the match loop
- [x] Adds an index to the state column in the `job_offer` table

Explain the motivation for making these changes. Does this pull request implement a feature or fix a bug? Is it a docs change or a typo fix?

In a continued effort to optimize the solver algo mentioned in [here](https://github.com/Lilypad-Tech/lilypad/issues/503), this PR introduces a bulk write functionality in the matcher loop decrease the number of network calls to the db. Additionally, we introduce a index to the state column in the `job_offers` table to help reduce the [look up time of job_offers in the solver controller](https://github.com/Lilypad-Tech/lilypad/blob/main/pkg/solver/controller.go#L330)

### Task/Issue reference

Closes: add_link_here

### Test plan

Please describe how reviewers can test the changes in this pull request. If the test plan is challenging to explain in text alone, a short video demonstration may be included.

1. Run the stack as usual
2. Run a few jobs and inspect that the `match_decisions` table is being written to and that you are getting job results back
3. Observe the `job_offers` schema in a database tool (pgadmin, datagrip, etc...) and confirm that the `idx_job_offers_state` index is present

### Details (optional)

Add any additional details that will help to review this pull request.

### Related issues or PRs (optional)

Add any related issues or PRs.
