### PR TITLE
fix(solver/stats): populate module_id in reputation events

### DIFF
--- a/pkg/solver/server.go
+++ b/pkg/solver/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/data"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/http"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/metricsDashboard"
+	"github.com/Lilypad-Tech/lilypad/v2/pkg/module/shortcuts"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/solver/stats"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/solver/store"
 	"github.com/Lilypad-Tech/lilypad/v2/pkg/system"
@@ -876,6 +877,7 @@ func (server *solverServer) downloadFiles(res corehttp.ResponseWriter, req *core
 		server.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).
+				WithModuleID(shortcuts.GetShortcut(deal.Deal.JobOffer.Module.Repo, deal.Deal.JobOffer.Module.Hash)).
 				Build(),
 		)
 	}); err != nil {
@@ -1118,6 +1120,7 @@ func (server *solverServer) jobOfferDownloadFiles(res corehttp.ResponseWriter, r
 		server.stats.PostReputation(deal.ResourceProvider,
 			stats.NewReputationBuilder().
 				WithJobCompletedNoValidation(true).
+				WithModuleID(shortcuts.GetShortcut(deal.Deal.JobOffer.Module.Repo, deal.Deal.JobOffer.Module.Hash)).
 				Build(),
 		)
 	}); err != nil {

--- a/pkg/solver/stats/reputation.go
+++ b/pkg/solver/stats/reputation.go
@@ -17,7 +17,7 @@ type Reputation struct {
 
 // The reputation builder constructs reputation from
 // reputation events. For now, it does not expose runtime
-// millis or module ID.
+// millis.
 type ReputationBuilder struct {
 	reputation Reputation
 }
@@ -43,6 +43,11 @@ func (b *ReputationBuilder) WithValidationLost(val bool) *ReputationBuilder {
 
 func (b *ReputationBuilder) WithJobFailed(val bool) *ReputationBuilder {
 	b.reputation.JobFailed = &val
+	return b
+}
+
+func (b *ReputationBuilder) WithModuleID(moduleID string) *ReputationBuilder {
+	b.reputation.ModuleID = moduleID
 	return b
 }
 

--- a/pkg/solver/stats/reputation.go
+++ b/pkg/solver/stats/reputation.go
@@ -17,7 +17,9 @@ type Reputation struct {
 
 // The reputation builder constructs reputation from
 // reputation events. For now, it does not expose runtime
-// millis.
+// millis or module ID. To work around this, WithModuleID
+// sets the module ID using a shortcut derived from the
+// module's repo and hash.
 type ReputationBuilder struct {
 	reputation Reputation
 }


### PR DESCRIPTION
### Summary

Populates the `module_id` field in reputation events by adding a `WithModuleID` method and using the repo+hash shortcut.